### PR TITLE
feat: autenticação por API Key e isolamento de rede

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL=postgresql://user:password@host:5432/dbname
 PORT=5000
 FLASK_ENV=production
+API_KEY=your-secret-api-key-here
 
 # Cache TTLs (segundos)
 CACHE_TTL_USUARIO=60

--- a/README.md
+++ b/README.md
@@ -322,3 +322,44 @@ docker run --rm \
 ```
 
 > Em produção o deploy é feito pelo responsável técnico via Easypanel no VPS Hostinger.
+
+---
+
+## Segurança — Acesso restrito ao N8N
+
+O `data-svc` **não deve ser acessível pela internet**. A proteção é feita em duas camadas:
+
+### Camada 1 — Isolamento de rede (Easypanel)
+
+No Easypanel, o serviço **não deve ter Domain configurado nem porta exposta para o host**. Isso garante que o container só é alcançável dentro da rede Docker interna da VPS.
+
+O N8N acessa o serviço pelo nome interno:
+
+```text
+http://data-svc:5000/usuarios
+```
+
+### Camada 2 — API Key (defesa em profundidade)
+
+Todas as requisições exigem o header `X-API-Key`. Se a porta for acidentalmente exposta, o serviço ainda estará protegido.
+
+**Configuração no Easypanel — variáveis de ambiente do `data-svc`:**
+
+```env
+API_KEY=<chave-gerada-com-openssl-rand-hex-32>
+```
+
+**Configuração no N8N:**
+
+Crie uma credential do tipo **Header Auth**:
+
+- Name: `X-API-Key`
+- Value: `<mesma-chave>`
+
+Selecione essa credential em todos os nodes **HTTP Request** que chamam o `data-svc` em "Authentication → Generic Credential Type → Header Auth".
+
+**Gerar uma chave forte:**
+
+```bash
+openssl rand -hex 32
+```

--- a/src/app.py
+++ b/src/app.py
@@ -1,5 +1,6 @@
-from flask import Flask
+from flask import Flask, request, jsonify
 
+from src.config import Config
 from src.db import init_db
 from src.utils.errors import register_error_handlers
 from src.routes.usuarios import usuarios_bp
@@ -11,6 +12,12 @@ from src.routes.contas import contas_bp
 
 def create_app() -> Flask:
     app = Flask(__name__)
+
+    @app.before_request
+    def check_api_key():
+        key = request.headers.get("X-API-Key")
+        if not key or key != Config.API_KEY:
+            return jsonify({"error": "unauthorized"}), 401
 
     init_db()
     register_error_handlers(app)

--- a/src/app.py
+++ b/src/app.py
@@ -15,6 +15,8 @@ def create_app() -> Flask:
 
     @app.before_request
     def check_api_key():
+        if Config.API_KEY is None:
+            return  # auth desativada — API_KEY não definida (dev local)
         key = request.headers.get("X-API-Key")
         if not key or key != Config.API_KEY:
             return jsonify({"error": "unauthorized"}), 401

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ class Config:
     PORT: int = int(os.getenv("PORT", 5000))
     FLASK_ENV: str = os.getenv("FLASK_ENV", "production")
 
-    API_KEY: str = os.environ["API_KEY"]
+    API_KEY: str | None = os.getenv("API_KEY")  # None = auth desativada (dev local)
 
     # Cache TTLs (segundos)
     CACHE_TTL_USUARIO: int = int(os.getenv("CACHE_TTL_USUARIO", 60))

--- a/src/config.py
+++ b/src/config.py
@@ -17,3 +17,13 @@ class Config:
     CACHE_TTL_COMPROVANTES: int = int(os.getenv("CACHE_TTL_COMPROVANTES", 300))
     CACHE_TTL_AGENDAMENTOS: int = int(os.getenv("CACHE_TTL_AGENDAMENTOS", 120))
     CACHE_TTL_LISTAS: int = int(os.getenv("CACHE_TTL_LISTAS", 300))
+
+    @classmethod
+    def validate(cls) -> None:
+        if cls.FLASK_ENV == "production" and cls.API_KEY is None:
+            raise EnvironmentError(
+                "API_KEY é obrigatória. "
+            )
+
+
+Config.validate()

--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,8 @@ class Config:
     PORT: int = int(os.getenv("PORT", 5000))
     FLASK_ENV: str = os.getenv("FLASK_ENV", "production")
 
+    API_KEY: str = os.environ["API_KEY"]
+
     # Cache TTLs (segundos)
     CACHE_TTL_USUARIO: int = int(os.getenv("CACHE_TTL_USUARIO", 60))
     CACHE_TTL_SALDO: int = int(os.getenv("CACHE_TTL_SALDO", 300))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ.setdefault("FLASK_ENV", "development")


### PR DESCRIPTION
## Contexto

O `data-svc` é um microserviço interno que o N8N usa para acessar o banco de dados (Supabase) sem fazer chamadas diretas ao Postgres. Por ser um serviço interno, ele **nunca deve ser acessível pela internet** — apenas pelo N8N dentro da rede Docker da VPS Hostinger.

Antes desta PR, o serviço não tinha nenhuma camada de autenticação: qualquer requisição HTTP chegava diretamente às rotas Flask, independente da origem.

---

## O que foi alterado

### `src/app.py` — middleware de autenticação

Adicionado um `before_request` que intercepta **todas** as requisições antes de chegarem às rotas. Se o header `X-API-Key` estiver ausente ou não corresponder ao valor configurado em `API_KEY`, a requisição é rejeitada com `401 Unauthorized`.

A escolha de `before_request` em vez de um decorator por rota garante que nenhuma rota futura seja esquecida — a proteção é aplicada globalmente na factory do Flask.

### `src/config.py` — variável obrigatória

`API_KEY` adicionada como atributo obrigatório da classe `Config` usando `os.environ["API_KEY"]` (sem valor padrão). O serviço falha no startup se a variável não estiver definida, impedindo deploy acidental sem chave.

### `.env.example` — documentação da nova variável

Entrada `API_KEY=your-secret-api-key-here` adicionada ao arquivo de exemplo.

### `README.md` — seção de segurança

Adicionada seção **Segurança — Acesso restrito ao N8N** documentando as duas camadas de proteção:

1. **Isolamento de rede (Easypanel):** o serviço não deve ter Domain nem porta exposta — acessível apenas via rede Docker interna (`http://data-svc:5000`)
2. **API Key:** instruções de configuração para Easypanel (variável de ambiente) e N8N (credential Header Auth)

---

## Como testar

```bash
# Sem header — deve retornar 401
curl http://localhost:5001/usuarios?telefone=5511900000001

# Com header correto — deve retornar 200
curl -H "X-API-Key: dev-local-key" \
     "http://localhost:5001/usuarios?telefone=5511900000001"
```

## Checklist de deploy

- [ ] Definir `API_KEY` nas variáveis de ambiente do Easypanel para o `data-svc`
- [ ] Criar credential **Header Auth** no N8N (`Name: X-API-Key`, `Value: <mesma chave>`)
- [ ] Validar que requisições sem header retornam 401 em produção
