### PR TITLE
feat: adiciona .env.local ao .gitignore, scripts de banco dev e implemente a recuperação do usuário por telefone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.env.local
 __pycache__/
 *.pyc
 *.pyo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: meire_dev
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - ./scripts/init.sql:/docker-entrypoint-initdb.d/01_schema.sql
+      - ./scripts/seed.sql:/docker-entrypoint-initdb.d/02_seed.sql
+
+volumes:
+  pg_data:

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -76,7 +76,7 @@ CREATE TABLE public.agendamentos (
   data_compromisso  date,
   hora_compromisso  time,
   status            text          DEFAULT 'pendente'
-                    CHECK (status IN ('pendente', 'confirmado', 'cancelado')),
+                    CHECK (status IN ('pendente', 'confirmado', 'agendado')),
   lembrete_enviado  boolean       DEFAULT false,  -- atualizado pelo workflow Lembretes automaticos
   data_lembrete     timestamp,
   tipo_agendamento  varchar(20)   DEFAULT 'unico',
@@ -135,14 +135,16 @@ CREATE TABLE public.contas_recorrentes (
   ativo          boolean        NOT NULL DEFAULT true,  -- soft delete
   created_at     timestamp      NOT NULL DEFAULT now(),
   updated_at     timestamp      NOT NULL DEFAULT now(),
-  CONSTRAINT contas_recorrentes_pkey PRIMARY KEY (id),
-  -- Unicidade por tipo (exceto boleto, que pode ter múltiplos)
-  CONSTRAINT contas_recorrentes_usuario_tipo_unique
-    UNIQUE (usuario_id, tipo) DEFERRABLE INITIALLY DEFERRED
-    -- A constraint real usa: WHERE tipo <> 'boleto' — ver migration 001
+  CONSTRAINT contas_recorrentes_pkey PRIMARY KEY (id)
 );
 
 CREATE INDEX idx_contas_recorrentes_usuario ON public.contas_recorrentes (usuario_id);
 CREATE INDEX idx_contas_recorrentes_lembrete
   ON public.contas_recorrentes (usuario_id, dia_vencimento)
   WHERE lembrete_ativo = true AND ativo = true;
+
+-- Índice parcial para UPSERT em POST /contas-recorrentes
+-- Garante unicidade de (usuario_id, tipo) apenas para tipos que não são 'boleto'
+CREATE UNIQUE INDEX contas_recorrentes_usuario_tipo_unique
+  ON public.contas_recorrentes (usuario_id, tipo)
+  WHERE tipo <> 'boleto';

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -1,0 +1,148 @@
+-- Comente ou remova estas linhas do schema antes de usar localmente:
+-- CREATE EXTENSION IF NOT EXISTS "pg_graphql";
+-- CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+-- CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+-- CREATE EXTENSION IF NOT EXISTS "pgjwt";
+-- CREATE EXTENSION IF NOT EXISTS "supabase_vault";
+
+-- Mantenha apenas:
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "unaccent";
+
+
+-- Criação da tabela usuarios
+CREATE TABLE public.usuarios (
+  id                   bigint        NOT NULL GENERATED ALWAYS AS IDENTITY,
+  numero_telefone      varchar(20),                          -- identificador principal, único
+  nome                 varchar(100),                         -- nome preferido do MEI
+  razao_social         text,                                 -- nome do negócio
+  email                varchar,
+  "cpfCnpj"            varchar,
+  interacao_previa     boolean       DEFAULT false,          -- false = onboarding ainda não concluído
+  estado_atual         text          DEFAULT 'menu',         -- estado da conversa atual
+  -- Campos preenchidos pelo onboarding — Bloco 1 (Pessoa)
+  dias_trabalho        text,                                 -- ex: 'seg,ter,qua,qui,sex'
+  horario_inicio       time,                                 -- ex: 08:00
+  horario_fim          time,                                 -- ex: 18:00
+  -- Campos preenchidos pelo onboarding — Bloco 2 (Empresa)
+  descricao_negocio    text,                                 -- síntese do áudio de apresentação do negócio
+  descricao_objetivo   text,                                 -- síntese do áudio de objetivo de vida
+  area_ajuda           text,                                 -- onde o MEI mais precisa de ajuda
+  tipo_negocio         varchar       CHECK (tipo_negocio IN ('produto', 'servico', 'ambos')),
+  preco_referencia     numeric,                              -- preço médio do produto/serviço principal
+  -- Integrações externas (fora do escopo do data-svc)
+  asaas_customer_id    varchar,
+  subconta_asaas_id    integer,
+  tem_subconta_ativa   boolean       DEFAULT false,
+  relatorio_atual_id   bigint,
+  -- Timestamps
+  data_primeiro_contato timestamp with time zone,
+  data_ultimo_contato   timestamp with time zone,
+  CONSTRAINT usuarios_pkey PRIMARY KEY (id)
+);
+
+-- Índice principal: busca por telefone em toda mensagem recebida
+CREATE UNIQUE INDEX idx_usuarios_telefone ON public.usuarios (numero_telefone);
+-- Índice para o workflow Retornar estado Menu
+CREATE INDEX idx_usuarios_estado_atual ON public.usuarios (estado_atual);
+
+
+-- Criação da tabela comprovantes
+CREATE TABLE public.comprovantes (
+  id             integer       NOT NULL GENERATED ALWAYS AS IDENTITY,
+  usuario_id     integer       NOT NULL REFERENCES public.usuarios(id),
+  item           text,                        -- descrição do item/serviço
+  quantidade     numeric(10,3),
+  valor_unitario numeric(12,2),
+  valor_total    numeric(12,2) NOT NULL,
+  operacao       text          NOT NULL,      -- 'venda' ou 'gasto'
+  data_venda     date,                        -- preenchido quando operacao = 'venda'
+  data_compra    date,                        -- preenchido quando operacao = 'gasto'
+  last_update    timestamp with time zone,
+  item_hash      varchar,                     -- hash SHA para idempotência no upsert
+  CONSTRAINT comprovantes_pkey PRIMARY KEY (id),
+  CONSTRAINT comprovantes_item_hash_key UNIQUE (item_hash)
+);
+
+CREATE INDEX idx_comprovantes_usuario_mes
+  ON public.comprovantes (usuario_id, data_venda, data_compra);
+
+
+-- Criação da tabela agendamentos
+CREATE TABLE public.agendamentos (
+  id                bigint        NOT NULL GENERATED ALWAYS AS IDENTITY,
+  usuario_id        bigint        REFERENCES public.usuarios(id),
+  nome_compromisso  varchar(200),
+  data_compromisso  date,
+  hora_compromisso  time,
+  status            text          DEFAULT 'pendente'
+                    CHECK (status IN ('pendente', 'confirmado', 'cancelado')),
+  lembrete_enviado  boolean       DEFAULT false,  -- atualizado pelo workflow Lembretes automaticos
+  data_lembrete     timestamp,
+  tipo_agendamento  varchar(20)   DEFAULT 'unico',
+  recorrencia_id    uuid,
+  data_criacao      timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+  data_modificacao  timestamp with time zone,
+  CONSTRAINT agendamentos_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_agendamentos_usuario_semana
+  ON public.agendamentos (usuario_id, data_compromisso)
+  WHERE status IN ('pendente', 'confirmado');
+
+CREATE INDEX idx_agendamentos_lembrete
+  ON public.agendamentos (data_compromisso, hora_compromisso)
+  WHERE lembrete_enviado = false AND status IN ('pendente', 'confirmado');
+
+
+-- Criação da tabela lista_compras
+CREATE TABLE public.lista_compras (
+  id               integer       NOT NULL GENERATED ALWAYS AS IDENTITY,
+  usuario_id       integer       NOT NULL REFERENCES public.usuarios(id),
+  nome_lista       varchar(255)  NOT NULL,
+  data_criacao     timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  data_atualizacao timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT lista_compras_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_lista_compras_usuario ON public.lista_compras (usuario_id);
+
+
+-- Criação da tabela itens_lista
+CREATE TABLE public.itens_lista (
+  id             integer        NOT NULL GENERATED ALWAYS AS IDENTITY,
+  lista_id       integer        NOT NULL REFERENCES public.lista_compras(id),
+  nome_item      varchar(255)   NOT NULL,
+  quantidade     integer        NOT NULL CHECK (quantidade > 0),
+  preco_unitario numeric(10,2)  NOT NULL CHECK (preco_unitario >= 0),
+  preco_total    numeric(12,2)  GENERATED ALWAYS AS (quantidade * preco_unitario) STORED,
+  CONSTRAINT itens_lista_pkey PRIMARY KEY (id),
+  CONSTRAINT itens_lista_lista_id_nome_item_key UNIQUE (lista_id, nome_item)
+);
+
+
+-- Criação da tabela contas_recorrentes
+CREATE TABLE public.contas_recorrentes (
+  id             integer        NOT NULL GENERATED ALWAYS AS IDENTITY,
+  usuario_id     bigint         NOT NULL REFERENCES public.usuarios(id) ON DELETE CASCADE,
+  tipo           varchar        NOT NULL
+                 CHECK (tipo IN ('aluguel', 'internet', 'luz', 'agua', 'boleto')),
+  descricao      varchar,                      -- obrigatório quando tipo = 'boleto'
+  valor          numeric,                      -- NULL para contas variáveis (luz, água)
+  dia_vencimento integer        CHECK (dia_vencimento BETWEEN 1 AND 31),
+  lembrete_ativo boolean        NOT NULL DEFAULT false,
+  pix_chave      text,                         -- incluso no lembrete mensal quando preenchido
+  ativo          boolean        NOT NULL DEFAULT true,  -- soft delete
+  created_at     timestamp      NOT NULL DEFAULT now(),
+  updated_at     timestamp      NOT NULL DEFAULT now(),
+  CONSTRAINT contas_recorrentes_pkey PRIMARY KEY (id),
+  -- Unicidade por tipo (exceto boleto, que pode ter múltiplos)
+  CONSTRAINT contas_recorrentes_usuario_tipo_unique
+    UNIQUE (usuario_id, tipo) DEFERRABLE INITIALLY DEFERRED
+    -- A constraint real usa: WHERE tipo <> 'boleto' — ver migration 001
+);
+
+CREATE INDEX idx_contas_recorrentes_usuario ON public.contas_recorrentes (usuario_id);
+CREATE INDEX idx_contas_recorrentes_lembrete
+  ON public.contas_recorrentes (usuario_id, dia_vencimento)
+  WHERE lembrete_ativo = true AND ativo = true;

--- a/scripts/seed.sql
+++ b/scripts/seed.sql
@@ -1,0 +1,30 @@
+INSERT INTO public.usuarios (
+  numero_telefone, nome, razao_social, estado_atual,
+  interacao_previa, tipo_negocio, data_primeiro_contato, data_ultimo_contato)
+VALUES
+  ('5511900000001', 'Dev Teste', 'Negocio Teste Ltda', 'menu',
+   true, 'servico', NOW(), CURRENT_DATE),
+  ('5511900000002', 'Maria Onboarding', 'Maria Costura', 'menu',
+   false, null, NOW(), CURRENT_DATE)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.comprovantes (
+  usuario_id, item, quantidade, valor_unitario, valor_total,
+  operacao, data_venda, item_hash)
+SELECT u.id, 'Consultoria', 1, 500.00, 500.00, 'venda',
+       CURRENT_DATE - 5, md5('consultoria-' || u.id::text)
+FROM public.usuarios u WHERE u.numero_telefone = '5511900000001';
+
+INSERT INTO public.comprovantes (
+  usuario_id, item, quantidade, valor_unitario, valor_total,
+  operacao, data_compra, item_hash)
+SELECT u.id, 'Aluguel escritório', 1, 800.00, 800.00, 'gasto',
+       CURRENT_DATE - 10, md5('aluguel-' || u.id::text)
+FROM public.usuarios u WHERE u.numero_telefone = '5511900000001';
+
+INSERT INTO public.agendamentos (
+  usuario_id, nome_compromisso, data_compromisso,
+  hora_compromisso, status, data_criacao, data_modificacao)
+SELECT u.id, 'Reunião com cliente', CURRENT_DATE + 2,
+       '14:00'::time, 'confirmado', NOW(), NOW()
+FROM public.usuarios u WHERE u.numero_telefone = '5511900000001';

--- a/src/queries/usuarios.py
+++ b/src/queries/usuarios.py
@@ -1,3 +1,5 @@
+from psycopg2.extras import RealDictCursor
+
 """
 Queries de usuários — funções puras que recebem conn + parâmetros e retornam rows.
 Nenhuma lógica HTTP ou de cache aqui.
@@ -7,7 +9,24 @@ Nenhuma lógica HTTP ou de cache aqui.
 def find_by_telefone(conn, telefone: str) -> dict | None:
     # TODO: implementar
     # Executar SELECT por numero_telefone, retornar dict ou None
-    pass
+    sql = """
+        SELECT
+            id, numero_telefone, nome, razao_social, email,
+            estado_atual, interacao_previa,
+            tipo_negocio, descricao_negocio, descricao_objetivo,
+            area_ajuda, preco_referencia,
+            dias_trabalho, horario_inicio, horario_fim,
+            data_primeiro_contato, data_ultimo_contato
+        FROM public.usuarios
+        WHERE numero_telefone = %(telefone)s
+        LIMIT 1;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"telefone": telefone})
+        row = cursor.fetchone()
+        return dict(row) if row else None
+    
 
 
 def upsert(conn, numero_telefone: str, nome: str, razao_social: str) -> dict:

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, abort
 
 from src.db import get_db_conn
 from src.cache import cache_get, cache_set, cache_invalidate
@@ -17,7 +17,22 @@ def get_usuario():
     # 3. chamar q.find_by_telefone(conn, telefone)
     # 4. armazenar no cache com TTL CACHE_TTL_USUARIO
     # 5. retornar 200 ou 404
-    pass
+    telefone = validate_telefone(request.args.get('telefone')) 
+      
+    cached = cache_get("usuario", telefone)
+    
+    if cached:
+        return jsonify(cached)
+    
+    with get_db_conn() as conn:
+        usuario = q.find_by_telefone(conn, telefone)
+        
+        if not usuario:
+            return jsonify({"error": "usuario_nao_encontrado"}), 404
+        
+        cache_set("usuario", telefone, usuario)
+        return usuario
+
 
 
 @usuarios_bp.route("/usuarios", methods=["POST"])

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify, abort
+from flask import Blueprint, request, jsonify
 
 from src.db import get_db_conn
 from src.cache import cache_get, cache_set, cache_invalidate
@@ -24,8 +24,8 @@ def get_usuario():
         if not usuario:
             return jsonify({"error": "usuario_nao_encontrado"}), 404
         
-        cache_set("usuario", telefone, usuario)
-        return usuario
+        cache_set("usuario", telefone, usuario, Config.CACHE_TTL_USUARIO)
+        return jsonify(usuario)
 
 
 

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -11,12 +11,6 @@ usuarios_bp = Blueprint("usuarios", __name__)
 
 @usuarios_bp.route("/usuarios", methods=["GET"])
 def get_usuario():
-    # TODO: implementar
-    # 1. validar query param ?telefone=
-    # 2. checar cache 'usuario:{telefone}'
-    # 3. chamar q.find_by_telefone(conn, telefone)
-    # 4. armazenar no cache com TTL CACHE_TTL_USUARIO
-    # 5. retornar 200 ou 404
     telefone = validate_telefone(request.args.get('telefone')) 
       
     cached = cache_get("usuario", telefone)


### PR DESCRIPTION
## Contexto

O data-svc é o serviço interno que centraliza o acesso ao banco para os fluxos do N8N, evitando chamadas diretas ao Postgres/Supabase. Para acelerar desenvolvimento local e reduzir atrito de onboarding, esta branch adiciona um setup completo de banco dev com schema/seed e implementa a recuperação de usuário por telefone no endpoint de usuários.

Antes desta PR:

1. O setup de banco local não estava padronizado no repositório.
2. A consulta de usuário por telefone ainda não estava implementada ponta a ponta em rota + query.

## O que foi alterado

### `.gitignore` — proteção de variáveis locais

1. Inclusão de `.env.local` no ignore para evitar versionamento de segredos e configurações locais.

### `docker-compose.yml` — banco local padronizado

1. Adicionado serviço Postgres 16 Alpine para ambiente dev.
2. Configurado bootstrap automático com volume persistente e execução de scripts de inicialização.

### `scripts/init.sql` — schema para desenvolvimento

1. Adicionado script de criação das tabelas principais do serviço.
2. Ajustadas extensões para compatibilidade com Postgres local (sem dependências específicas de Supabase).

### `scripts/seed.sql` — dados mínimos para teste

1. Inseridos dados de exemplo de usuários, comprovantes e agendamentos.
2. Seed permite validar rapidamente endpoints sem preparação manual.

### `src/queries/usuarios.py` — query de busca por telefone

1. Implementada função `find_by_telefone` com `SELECT` em `public.usuarios` por `numero_telefone`.
2. Retorno padronizado em `dict` ou `None`.

### `src/routes/usuarios.py` — GET /usuarios

1. Implementada rota `GET /usuarios` com validação de telefone.
2. Adicionado uso de cache namespace `usuario`.
3. Quando não encontra usuário, retorna `404` com erro `usuario_nao_encontrado`.
4. Quando encontra, retorna payload do usuário e popula cache.

## Como testar

### Pré-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src.app run --port 5001 --debug
```

### Cenários de validação

1. Buscar usuário existente:

```bash
curl "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: `200` com dados do usuário.
### README.md — documentação de setup local

1. Documentação atualizada com fluxo de ambiente local, docker compose, scripts SQL e execução do servidor para testes.

2. Buscar usuário inexistente:

```bash
curl "http://localhost:5001/usuarios?telefone=5511999999999"
```

Esperado: `404` com `error = usuario_nao_encontrado`.

3. Telefone inválido/ausente:

```bash
curl "http://localhost:5001/usuarios"
```

Esperado: `400` por validação.

## Checklist de merge

- [ ]  Confirmar que `.env.local` não está sendo versionado.
- [ ]  Validar subida do Postgres local via docker compose sem erro.
- [ ]  Validar execução de `init.sql` e `seed.sql` na primeira inicialização.
- [ ]  Validar `GET /usuarios` para casos `200`, `404` e `400`.
- [ ]  Confirmar documentação alinhada com o fluxo real de desenvolvimento local.
