### PR TITLE
refactor: centralização e  padronização de respostas da API e tratamento de erros

### DIFF
--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -5,6 +5,7 @@ from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
 from src.utils.validators import validate_telefone, require_fields
 import src.queries.usuarios as q
+from src.utils.api_response import fail, ok
 
 usuarios_bp = Blueprint("usuarios", __name__)
 
@@ -22,10 +23,10 @@ def get_usuario():
         usuario = q.find_by_telefone(conn, telefone)
         
         if not usuario:
-            return jsonify({"error": "usuario_nao_encontrado"}), 404
+            return fail("usuario_nao_encontrado", status_code=404)
         
         cache_set("usuario", telefone, usuario, Config.CACHE_TTL_USUARIO)
-        return jsonify(usuario)
+        return ok(200, usuario)
 
 
 

--- a/src/utils/api_response.py
+++ b/src/utils/api_response.py
@@ -1,0 +1,17 @@
+from flask import jsonify
+
+def fail(code: str, detail: str | None = None, status_code: int = 400):
+    payload = {}
+    payload["error"] = code
+    
+    if detail:
+        payload["detail"] = detail
+    
+    return jsonify(payload), status_code
+
+def ok(status_code: int = 204, data = None):
+    if status_code == 204 or data is None:
+        return "", status_code
+    
+    return jsonify(data), status_code
+    

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -1,19 +1,20 @@
-from flask import Flask, jsonify
+from flask import Flask
+from src.utils.api_response import fail
 
 
 def register_error_handlers(app: Flask):
     @app.errorhandler(400)
     def bad_request(e):
-        return jsonify({"error": "bad_request", "detail": str(e)}), 400
+        return fail("bad_request", str(e), 400)
 
     @app.errorhandler(404)
     def not_found(e):
-        return jsonify({"error": "not_found"}), 404
+        return fail("not_found", status_code=404)
 
     @app.errorhandler(422)
     def unprocessable(e):
-        return jsonify({"error": "unprocessable_entity", "detail": str(e)}), 422
+        return fail("unprocessable_entity", str(e), 422)
 
     @app.errorhandler(500)
     def internal_error(e):
-        return jsonify({"error": "internal_server_error"}), 500
+        return fail("internal_server_error", status_code=500)


### PR DESCRIPTION
## Contexto

Esta branch introduz um padrão único de respostas HTTP para sucesso e erro, reduzindo inconsistência entre rotas e simplificando o consumo pelo N8N.

Antes desta PR:

1. As respostas de sucesso e erro não tinham um ponto único de padronização.
2. O tratamento global de erros não estava integrado ao mesmo helper de resposta usado nas rotas.
3. A rota de usuários por telefone ainda estava sendo consolidada junto com o novo padrão.

## O que foi alterado

### `src/utils/api_response.py` — padronização de respostas

1. Centralizados helpers `ok` e `fail` para concentrar a montagem de retorno HTTP.
2. `fail` padroniza payload de erro com `error` e `detail` opcional.
3. `ok` centraliza retornos de sucesso e o caso de `204` sem body.

### `src/utils/errors.py` — tratamento global usando o mesmo padrão

1. Handlers globais (`400`, `404`, `422`, `500`) passaram a utilizar `fail`.
2. Erros de validação e erros de rota passam por um formato consistente de resposta.

### `src/routes/usuarios.py` — GET /usuarios

1. Retorno padronizado com o `fail` e o `ok`.
2. Quando não encontra usuário, retorna `404` com erro `usuario_nao_encontrado` via helper `fail`.
3. Quando encontra, retorna payload do usuário com `200` via helper `ok` e popula cache.

## Como testar

### Pré-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src.app run --port 5001 --debug
```

### Cenários de validação

1. Buscar usuário existente:

```bash
curl "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: `200` com dados do usuário.

2. Buscar usuário inexistente:

```bash
curl "http://localhost:5001/usuarios?telefone=5511999999999"
```

Esperado: `404` com `error = usuario_nao_encontrado`.

3. Telefone inválido/ausente:

```bash
curl "http://localhost:5001/usuarios"
```

Esperado: `400` por validação.

4. Validar padronização de erro global (`404` de rota inexistente):

```bash
curl "http://localhost:5001/rota-inexistente"
```

Esperado: `404` com payload no padrão `fail`.

## Checklist de merge
- [ ]  Validar `GET /usuarios` para casos `200`, `404` e `400`.
- [ ]  Validar padronização de erros globais (`400`, `404`, `422`, `500`) via `fail`.
- [ ]  Confirmar documentação alinhada com o fluxo real de desenvolvimento local.
