### PR TITLE
fix: corrige o get da env API_KEY retornando None se não existir para validação correta da auth

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ class Config:
     PORT: int = int(os.getenv("PORT", 5000))
     FLASK_ENV: str = os.getenv("FLASK_ENV", "production")
 
-    API_KEY: str | None = os.getenv("API_KEY")  # None = auth desativada (dev local)
+    API_KEY: str | None = (os.getenv("API_KEY") or "").strip() or None   # None = auth desativada (dev local)
 
     # Cache TTLs (segundos)
     CACHE_TTL_USUARIO: int = int(os.getenv("CACHE_TTL_USUARIO", 60))


### PR DESCRIPTION
## Contexto

Esta branch corrige o problema em que a autenticação por API key não funcionava como esperado, validando sempre e retornando `401` em todas as rotas, mesmo sem a `API_KEY` em modo de desenvolvimento.

Antes desta PR:

1. A leitura da `API_KEY` não normalizava todos os cenários de valor "não informado de fato".
2. Isso podia ativar/desativar a autenticação de forma inconsistente entre ambientes.
3. Também podia deixar a validação ativa continuamente, mesmo em ambiente de desenvolvimento.
4. O comportamento esperado de auth em dev e produção ficava sujeito ao formato da variável no ambiente.

## O que foi alterado

### `src/config.py` - normalização da `API_KEY`

1. A `API_KEY` passou a ser lida e normalizada com:
   - `(os.getenv("API_KEY") or "").strip() or None`
2. Com isso, os casos abaixo passam a virar `None` de forma consistente:
   - variável não definida
   - variável vazia (`API_KEY=`)
   - variável com somente espaços (`API_KEY="   "`)
3. A validação de produção continua exigindo `API_KEY` obrigatória.

### `src/app.py` - fluxo de autenticação no `before_request`

1. Quando `Config.API_KEY` é `None`, a autenticação permanece desativada (uso local/dev).
2. Quando `API_KEY` está definida, toda requisição precisa de `X-API-Key` válido.
3. Em caso de ausência ou divergência da chave, a API retorna `401` com `{ "error": "unauthorized" }`.

## Como testar

### Pré-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src.app run --port 5001 --debug
```

### Cenários de validação

1. `API_KEY` não informada (auth desativada em dev)

```bash
unset API_KEY
curl "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: fluxo normal da rota (`200` ou `404`, conforme dados), sem exigir header.

2. `API_KEY` vazia ou com espaços (tratada como ausente)

```bash
export API_KEY="   "
curl "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: mesmo comportamento de API_KEY ausente em dev.

3. `API_KEY` configurada e header ausente

```bash
export API_KEY=minha-chave
curl "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: `401` com `error = unauthorized`.

4. `API_KEY` configurada e header inválido

```bash
curl -H "X-API-Key: chave-errada" "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: `401` com `error = unauthorized`.

5. `API_KEY` configurada e header válido

```bash
curl -H "X-API-Key: minha-chave" "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: fluxo normal da rota (`200` ou `404`, conforme dados).

## Checklist de merge
- [ ] Validar auth com `API_KEY` ausente, vazia e preenchida.
- [ ] Confirmar retorno `401 unauthorized` para header ausente ou inválido quando `API_KEY` estiver ativa.
- [ ] Confirmar fluxo normal da rota com header correto.
- [ ] Confirmar que, em produção, a aplicação falha ao subir sem `API_KEY` válida.
- [ ] Confirmar documentação alinhada com o fluxo real de desenvolvimento local.
