### PR TITLE
feat: implementa endpoints de comprovantes (saldo, listagem e upsert) com validação de modo e invalidação de cache por prefixo

### DIFF
--- a/src/cache.py
+++ b/src/cache.py
@@ -30,3 +30,10 @@ def cache_invalidate(namespace: str, key: str = None):
         c.pop(key, None)
     else:
         c.clear()
+
+def cache_invalidate_prefix(namespace: str, prefix: str):
+    """Invalida chaves que começam com o prefixo informado """
+    c = get_cache(namespace)
+    for k in list(c.keys()):
+        if str(k).startswith(prefix):
+            c.pop(k, None)

--- a/src/queries/comprovantes.py
+++ b/src/queries/comprovantes.py
@@ -6,8 +6,6 @@ Queries de comprovantes — funções puras que recebem conn + parâmetros e ret
 
 
 def get_saldo(conn, usuario_id: int, mes: str) -> dict:
-    # Executar SELECT SUM por operacao filtrado pelo mês
-    # Retornar { total_vendas, total_gastos, saldo }
     sql = """
         SELECT
             COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)::numeric(14,2) AS total_vendas,
@@ -34,10 +32,6 @@ def get_saldo(conn, usuario_id: int, mes: str) -> dict:
 
 
 def list_comprovantes(conn, usuario_id: int, mes: str, modo: str) -> list[dict]:
-    # modo: 'relatorio' | 'gastos' | 'vendas'
-    # Normalizar modo: 'gastos' → 'gasto', 'vendas' → 'venda'
-    # Executar SELECT filtrado por mes e modo
-    # Retornar lista de dicts
     modo = modo.strip().lower()
     modo = {"gastos": "gasto", "vendas": "venda"}.get(modo, modo)
     
@@ -78,8 +72,36 @@ def list_comprovantes(conn, usuario_id: int, mes: str, modo: str) -> list[dict]:
     
 
 
-def upsert(conn, usuario_id: int, data: dict) -> dict:
-    # TODO: implementar
-    # Executar INSERT ... ON CONFLICT (item_hash) DO UPDATE
-    # Retornar dict com dados do comprovante
-    pass
+def upsert(conn, usuario_id: int, data: dict) -> dict:    
+    params = {
+        "usuario_id": usuario_id,
+        "item": data.get("item"),
+        "quantidade": data.get("quantidade"),
+        "valor_unitario": data.get("valor_unitario"),
+        "valor_total": data.get("valor_total"),
+        "operacao": data.get("operacao"),
+        "item_hash": data.get("item_hash"),
+        "data_venda": data.get("data_venda"),
+        "data_compra": data.get("data_compra"),
+    }
+    
+    sql = """
+        INSERT INTO public.comprovantes (
+            usuario_id, item, quantidade, valor_unitario, valor_total,
+            data_compra, data_venda, operacao, last_update, item_hash)
+        VALUES (
+            %(usuario_id)s, %(item)s, %(quantidade)s, %(valor_unitario)s, %(valor_total)s,
+            %(data_compra)s, %(data_venda)s, %(operacao)s, NOW(), %(item_hash)s)
+        ON CONFLICT (item_hash)
+        DO UPDATE SET
+            quantidade    = EXCLUDED.quantidade,
+            valor_unitario = EXCLUDED.valor_unitario,
+            valor_total   = EXCLUDED.valor_total,
+            last_update   = EXCLUDED.last_update
+        RETURNING id, operacao, item, valor_total, data_compra, data_venda;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, params)
+        row = cursor.fetchone()
+        return dict(row)
+    

--- a/src/queries/comprovantes.py
+++ b/src/queries/comprovantes.py
@@ -34,12 +34,48 @@ def get_saldo(conn, usuario_id: int, mes: str) -> dict:
 
 
 def list_comprovantes(conn, usuario_id: int, mes: str, modo: str) -> list[dict]:
-    # TODO: implementar
     # modo: 'relatorio' | 'gastos' | 'vendas'
     # Normalizar modo: 'gastos' → 'gasto', 'vendas' → 'venda'
     # Executar SELECT filtrado por mes e modo
     # Retornar lista de dicts
-    pass
+    modo = modo.strip().lower()
+    modo = {"gastos": "gasto", "vendas": "venda"}.get(modo, modo)
+    
+    sql = """
+        SELECT
+            id,
+            operacao,
+            item,
+            quantidade,
+            valor_unitario,
+            valor_total,
+        CASE
+            WHEN operacao = 'gasto' THEN data_compra
+            WHEN operacao = 'venda' THEN data_venda
+        END AS data_lancamento
+        FROM public.comprovantes
+        WHERE usuario_id = %(usuario_id)s
+        AND (
+            -- filtro de modo: 'relatorio' traz tudo; 'gastos' só gastos; 'vendas' só vendas
+            %(modo)s = 'relatorio'
+            OR operacao = %(modo)s  -- 'gastos' → 'gasto'; 'vendas' → 'venda' (normalizar no código)
+        )
+        AND CASE
+            WHEN operacao = 'gasto' THEN data_compra
+            WHEN operacao = 'venda' THEN data_venda
+        END >= date_trunc('month', TO_DATE(%(referencia)s, 'YYYY-MM'))
+        AND CASE
+            WHEN operacao = 'gasto' THEN data_compra
+            WHEN operacao = 'venda' THEN data_venda
+        END < date_trunc('month', TO_DATE(%(referencia)s, 'YYYY-MM')) + INTERVAL '1 month'
+        ORDER BY data_lancamento DESC;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"usuario_id": usuario_id, "modo": modo, "referencia": mes})
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+    
 
 
 def upsert(conn, usuario_id: int, data: dict) -> dict:

--- a/src/queries/comprovantes.py
+++ b/src/queries/comprovantes.py
@@ -1,13 +1,36 @@
+from psycopg2.extras import RealDictCursor
+
 """
 Queries de comprovantes — funções puras que recebem conn + parâmetros e retornam rows.
 """
 
 
 def get_saldo(conn, usuario_id: int, mes: str) -> dict:
-    # TODO: implementar
     # Executar SELECT SUM por operacao filtrado pelo mês
     # Retornar { total_vendas, total_gastos, saldo }
-    pass
+    sql = """
+        SELECT
+            COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)::numeric(14,2) AS total_vendas,
+            COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0)::numeric(14,2) AS total_gastos,
+            (COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)
+            - COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0))::numeric(14,2) AS saldo
+        FROM public.comprovantes
+        WHERE usuario_id = %(usuario_id)s
+        AND (
+            (operacao = 'venda'
+            AND data_venda >= date_trunc('month', TO_DATE(%(referencia)s, 'YYYY-MM'))
+            AND data_venda  < date_trunc('month', TO_DATE(%(referencia)s, 'YYYY-MM')) + INTERVAL '1 month')
+            OR
+            (operacao = 'gasto'
+            AND data_compra >= date_trunc('month', TO_DATE(%(referencia)s, 'YYYY-MM'))
+            AND data_compra  < date_trunc('month', TO_DATE(%(referencia)s, 'YYYY-MM')) + INTERVAL '1 month')
+        );
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"usuario_id": usuario_id, "referencia": mes})
+        row = cursor.fetchone()
+        return dict(row)
 
 
 def list_comprovantes(conn, usuario_id: int, mes: str, modo: str) -> list[dict]:

--- a/src/routes/comprovantes.py
+++ b/src/routes/comprovantes.py
@@ -1,11 +1,11 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request
 
 from src.db import get_db_conn
-from src.cache import cache_get, cache_set, cache_invalidate
+from src.cache import cache_get, cache_invalidate_prefix, cache_set
 from src.config import Config
-from src.utils.validators import validate_mes, validate_modo,require_fields
+from src.utils.validators import validate_comprovante_payload, validate_mes, validate_modo
 import src.queries.comprovantes as q
-from src.utils.api_response import ok
+from src.utils.api_response import fail, ok
 
 comprovantes_bp = Blueprint("comprovantes", __name__)
 
@@ -30,8 +30,7 @@ def get_saldo(usuario_id: int):
 @comprovantes_bp.route("/usuarios/<int:usuario_id>/comprovantes", methods=["GET"])
 def list_comprovantes(usuario_id: int):
     mes = validate_mes(request.args.get("mes"))
-    modo = validate_modo(request.args.get("modo"))
-    
+    modo = validate_modo(request.args.get("modo"))  
     
     comprovantes = cache_get("comprovantes", f"{usuario_id}:{mes}:{modo}")
     if comprovantes:
@@ -47,9 +46,19 @@ def list_comprovantes(usuario_id: int):
 
 @comprovantes_bp.route("/usuarios/<int:usuario_id>/comprovantes", methods=["POST"])
 def create_comprovante(usuario_id: int):
-    # TODO: implementar
-    # 1. validar body (item, quantidade, valor_unitario, valor_total, operacao, item_hash)
-    # 2. chamar q.upsert(conn, usuario_id, body)
-    # 3. invalidar cache 'saldo:{usuario_id}:*' e 'comprovantes:{usuario_id}:*'
-    # 4. retornar 200 com dados do comprovante inserido/atualizado
-    pass
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+    
+    body = validate_comprovante_payload(body)
+    
+    with get_db_conn() as conn:
+        comprovante = q.upsert(conn, usuario_id, body)
+        
+        cache_invalidate_prefix("saldo", f"{usuario_id}:")
+        cache_invalidate_prefix("comprovantes", f"{usuario_id}:")
+        
+        return ok(200, comprovante)
+        
+
+    

--- a/src/routes/comprovantes.py
+++ b/src/routes/comprovantes.py
@@ -3,7 +3,7 @@ from flask import Blueprint, request, jsonify
 from src.db import get_db_conn
 from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
-from src.utils.validators import validate_mes, require_fields
+from src.utils.validators import validate_mes, validate_modo,require_fields
 import src.queries.comprovantes as q
 from src.utils.api_response import ok
 
@@ -29,13 +29,20 @@ def get_saldo(usuario_id: int):
 
 @comprovantes_bp.route("/usuarios/<int:usuario_id>/comprovantes", methods=["GET"])
 def list_comprovantes(usuario_id: int):
-    # TODO: implementar
-    # 1. validar ?mes=YYYY-MM e ?modo=relatorio|gastos|vendas
-    # 2. checar cache 'comprovantes:{usuario_id}:{YYYY-MM}:{modo}'
-    # 3. chamar q.list_comprovantes(conn, usuario_id, mes, modo)
-    # 4. armazenar no cache com TTL CACHE_TTL_COMPROVANTES
-    # 5. retornar lista de comprovantes
-    pass
+    mes = validate_mes(request.args.get("mes"))
+    modo = validate_modo(request.args.get("modo"))
+    
+    
+    comprovantes = cache_get("comprovantes", f"{usuario_id}:{mes}:{modo}")
+    if comprovantes:
+        return ok(200, comprovantes)
+    
+    with get_db_conn() as conn:
+        comprovantes = q.list_comprovantes(conn, usuario_id, mes, modo)
+        
+        cache_set("comprovantes", f"{usuario_id}:{mes}:{modo}", comprovantes, Config.CACHE_TTL_COMPROVANTES)
+        
+        return ok(200, comprovantes)
 
 
 @comprovantes_bp.route("/usuarios/<int:usuario_id>/comprovantes", methods=["POST"])

--- a/src/routes/comprovantes.py
+++ b/src/routes/comprovantes.py
@@ -5,19 +5,26 @@ from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
 from src.utils.validators import validate_mes, require_fields
 import src.queries.comprovantes as q
+from src.utils.api_response import ok
 
 comprovantes_bp = Blueprint("comprovantes", __name__)
 
 
 @comprovantes_bp.route("/usuarios/<int:usuario_id>/saldo", methods=["GET"])
 def get_saldo(usuario_id: int):
-    # TODO: implementar
-    # 1. validar query param ?mes=YYYY-MM
-    # 2. checar cache 'saldo:{usuario_id}:{YYYY-MM}'
-    # 3. chamar q.get_saldo(conn, usuario_id, mes)
-    # 4. armazenar no cache com TTL CACHE_TTL_SALDO
-    # 5. retornar { mes, total_vendas, total_gastos, saldo }
-    pass
+    mes = validate_mes(request.args.get("mes"))
+    
+    saldo_mes = cache_get("saldo", usuario_id)
+    if saldo_mes:
+        return ok(200, saldo_mes)
+    
+    with get_db_conn() as conn:
+        saldo_mes = q.get_saldo(conn, usuario_id, mes)     
+
+        cache_set("saldo", usuario_id, saldo_mes, Config.CACHE_TTL_SALDO)
+        
+        return ok(200, saldo_mes)
+    
 
 
 @comprovantes_bp.route("/usuarios/<int:usuario_id>/comprovantes", methods=["GET"])

--- a/src/routes/comprovantes.py
+++ b/src/routes/comprovantes.py
@@ -14,14 +14,14 @@ comprovantes_bp = Blueprint("comprovantes", __name__)
 def get_saldo(usuario_id: int):
     mes = validate_mes(request.args.get("mes"))
     
-    saldo_mes = cache_get("saldo", usuario_id)
+    saldo_mes = cache_get("saldo", f"{usuario_id}:{mes}")
     if saldo_mes:
         return ok(200, saldo_mes)
     
     with get_db_conn() as conn:
         saldo_mes = q.get_saldo(conn, usuario_id, mes)     
 
-        cache_set("saldo", usuario_id, saldo_mes, Config.CACHE_TTL_SALDO)
+        cache_set("saldo", f"{usuario_id}:{mes}", saldo_mes, Config.CACHE_TTL_SALDO)
         
         return ok(200, saldo_mes)
     

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -56,7 +56,7 @@ def validate_modo(modo: str) -> str:
 def validate_comprovante_payload(body: dict) -> dict:
     operacao_raw = str(body.get("operacao", "")).strip().lower()
     operacao = _OPERACAO_ALIASES.get(operacao_raw)
-    if operacao not in _OPERACAO_ALIASES:
+    if operacao is None:
         permitidos = ", ".join(sorted(_OPERACAO_ALIASES.keys()))
         abort(400, description=f"o campo 'operacao' está inválido. Use: {permitidos}")
         
@@ -81,9 +81,13 @@ def validate_comprovante_payload(body: dict) -> dict:
     data_venda = None   
     data_compra = None    
     if operacao == "venda":
-        data_venda = body.get("data_venda")
+        data_venda = str(body.get("data_venda", "")).strip()
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", data_venda):
+            abort(400, description="o campo 'data_venda' deve estar no formato YYYY-MM-DD")
     else:
-        data_compra = body.get("data_compra")
+        data_compra = str(body.get("data_compra", "")).strip()
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", data_compra):
+            abort(400, description="o campo 'data_compra' deve estar no formato YYYY-MM-DD")
 
     if operacao == "venda" and not data_venda:
         abort(400, description="o campo 'data_venda' é obrigatório para operacao='venda'")

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,6 +1,7 @@
+from decimal import Decimal, InvalidOperation
 import re
 from typing import Final
-from flask import request, abort
+from flask import abort
 
 
 _MODO_ALIASES: Final[dict[str, str]] = {
@@ -9,6 +10,13 @@ _MODO_ALIASES: Final[dict[str, str]] = {
     "gasto": "gasto",
     "venda": "venda",
     "relatorio": "relatorio",
+}
+
+_OPERACAO_ALIASES: Final[dict[str, str]] = {
+    "gastos": "gasto",
+    "vendas": "venda",
+    "gasto": "gasto",
+    "venda": "venda",
 }
 
 
@@ -45,4 +53,44 @@ def validate_modo(modo: str) -> str:
     return normalizado
 
 
+def validate_comprovante_payload(body: dict) -> dict:
+    operacao_raw = str(body.get("operacao", "")).strip().lower()
+    operacao = _OPERACAO_ALIASES.get(operacao_raw)
+    if operacao not in _OPERACAO_ALIASES:
+        permitidos = ", ".join(sorted(_OPERACAO_ALIASES.keys()))
+        abort(400, description=f"o campo 'operacao' está inválido. Use: {permitidos}")
+        
+    item = str(body.get("item", "")).strip()
+    if not item:
+        abort(400, description="o campo 'item' não pode ser vazio")
 
+    item_hash = str(body.get("item_hash", "")).strip()
+    if not item_hash:
+        abort(400, description="o campo 'item_hash' não pode ser vazio")
+    
+    try:
+        qtd = Decimal(str(body.get("quantidade")))
+        vu = Decimal(str(body.get("valor_unitario")))
+        vt = Decimal(str(body.get("valor_total")))
+    except (InvalidOperation, TypeError):
+        abort(400, description="quantidade, valor_unitario e valor_total devem ser numéricos")
+
+    if qtd <= 0 or vu < 0 or vt < 0:
+        abort(400, description="o campo 'quantidade' deve ser > 0 e os valores >= 0")
+     
+    data_venda = None   
+    data_compra = None    
+    if operacao == "venda":
+        data_venda = body.get("data_venda")
+    else:
+        data_compra = body.get("data_compra")
+
+    if operacao == "venda" and not data_venda:
+        abort(400, description="o campo 'data_venda' é obrigatório para operacao='venda'")
+    if operacao == "gasto" and not data_compra:
+        abort(400, description="o campo 'data_compra' é obrigatório para operacao='gasto'")
+
+    body["operacao"] = operacao
+    body["item"] = item
+    body["item_hash"] = item_hash
+    return body

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,5 +1,15 @@
 import re
+from typing import Final
 from flask import request, abort
+
+
+_MODO_ALIASES: Final[dict[str, str]] = {
+    "gastos": "gasto",
+    "vendas": "venda",
+    "gasto": "gasto",
+    "venda": "venda",
+    "relatorio": "relatorio",
+}
 
 
 def require_fields(body: dict, *fields: str):
@@ -21,3 +31,18 @@ def validate_telefone(telefone: str) -> str:
     if not telefone or not re.match(r"^\d{10,13}$", telefone):
         abort(400, description="parâmetro 'telefone' inválido")
     return telefone
+
+
+def validate_modo(modo: str) -> str:
+    """Valida o modo de um comprovante em relatorio | gastos | vendas"""
+    raw = (modo or "").strip().lower()
+    normalizado = _MODO_ALIASES.get(raw)
+
+    if normalizado is None:
+        permitidos = ", ".join(sorted(_MODO_ALIASES.keys()))
+        abort(400, description=f"parâmetro 'modo' inválido. Use: {permitidos}")
+
+    return normalizado
+
+
+


### PR DESCRIPTION
## Contexto

Esta branch implementa os endpoints de comprovantes e saldo do usuario, incluindo validacoes de entrada e comportamento de cache para leitura e escrita.

Antes desta PR:

1. As rotas de comprovantes e saldo estavam com `TODO` e sem implementacao funcional.
2. Nao havia validacao dedicada para o parametro `modo` da listagem de comprovantes.
3. O payload do `POST /usuarios/<usuario_id>/comprovantes` nao tinha validacao completa de campos e regras por operacao.
4. A invalidacao de cache apos upsert nao cobria corretamente os cenarios por mes no namespace de saldo.

## O que foi alterado

### `src/routes/comprovantes.py` - implementacao das rotas

1. Implementado `GET /usuarios/<usuario_id>/saldo` com:
   - validacao de `mes` (`YYYY-MM`)
   - leitura de cache `saldo:{usuario_id}:{mes}`
   - consulta em banco via query dedicada
   - persistencia em cache com `Config.CACHE_TTL_SALDO`
2. Implementado `GET /usuarios/<usuario_id>/comprovantes` com:
   - validacao de `mes`
   - validacao e normalizacao de `modo`
   - cache `comprovantes:{usuario_id}:{mes}:{modo}`
   - consulta em banco e cache com `Config.CACHE_TTL_COMPROVANTES`
3. Implementado `POST /usuarios/<usuario_id>/comprovantes` com:
   - validacao de body JSON
   - validacao de payload de comprovante
   - upsert em banco
   - invalidacao de cache por prefixo para `saldo` e `comprovantes`

### `src/queries/comprovantes.py` - queries de saldo, listagem e upsert

1. Implementada query de saldo mensal com agregacoes:
   - `total_vendas`
   - `total_gastos`
   - `saldo = vendas - gastos`
2. Implementada listagem de comprovantes com filtro por:
   - usuario
   - mes
   - modo (`relatorio`, `gasto`, `venda`)
3. Implementado `upsert` por `item_hash` com `ON CONFLICT`, retornando o registro inserido/atualizado.

### `src/utils/validators.py` - validacoes para comprovantes

1. Adicionado `validate_modo` com aliases e normalizacao de entrada.
2. Adicionado `validate_comprovante_payload` com validacao de:
   - `operacao` (`gasto`/`venda`, incluindo aliases)
   - `item` e `item_hash` obrigatorios
   - campos numericos (`quantidade`, `valor_unitario`, `valor_total`)
   - regra de data obrigatoria por operacao (`data_compra` ou `data_venda`)

### `src/cache.py` - invalidacao por prefixo

1. Adicionado `cache_invalidate_prefix(namespace, prefix)`.
2. Esse método invalida todas as chaves do `namespace` que iniciam com o `prefix`.
3. Usado nas rotas para invalidar todas as chaves de um usuario em vez de apenas uma chave isolada.
4. Corrigida a estrategia de invalidacao para o padrao real das chaves (`{usuario_id}:{mes}`), evitando cache stale apos upsert.

## Como testar

### Pre-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src/app run --port 5001 --debug
```

2. Para evitar bloqueio por API key no dev local:

```bash
unset API_KEY
```

### Cenarios de validacao

1. Buscar usuario para testes (obter `id`)

```bash
curl "http://localhost:5001/usuarios?telefone=5511900000001"
```

Esperado: retorno `200` com objeto de usuario contendo `id`.

2. Consultar saldo do mes

```bash
curl "http://localhost:5001/usuarios/1/saldo?mes=2026-04"
```

Esperado: `200` com `total_vendas`, `total_gastos` e `saldo`.

3. Validar erro de `mes` ausente

```bash
curl "http://localhost:5001/usuarios/1/saldo"
```

Esperado: `400` por parametro `mes` invalido/ausente.

5. Listar comprovantes no modo relatorio

```bash
curl "http://localhost:5001/usuarios/1/comprovantes?mes=2026-04&modo=relatorio"
```

Esperado: `200` com lista de comprovantes do mes.

6. Validar filtro por modo

```bash
curl "http://localhost:5001/usuarios/1/comprovantes?mes=2026-04&modo=gastos"
curl "http://localhost:5001/usuarios/1/comprovantes?mes=2026-04&modo=vendas"
```

Esperado: `200`; cada chamada retorna apenas operacoes correspondentes.

7. Validar erro para modo invalido

```bash
curl "http://localhost:5001/usuarios/1/comprovantes?mes=2026-04&modo=foo"
```

Esperado: `400` indicando valores permitidos de `modo`.

8. Inserir comprovante de venda

```bash
curl -X POST "http://localhost:5001/usuarios/1/comprovantes" \
  -H "Content-Type: application/json" \
  -d '{
    "item": "Consultoria abril",
    "quantidade": 1,
    "valor_unitario": 500,
    "valor_total": 500,
    "operacao": "venda",
    "item_hash": "consultoria-abril-1",
    "data_venda": "2026-04-05"
  }'
```

Esperado: `200` com comprovante inserido/atualizado.

9. Repetir POST com mesmo `item_hash` (upsert)

```bash
curl -X POST "http://localhost:5001/usuarios/1/comprovantes" \
  -H "Content-Type: application/json" \
  -d '{
    "item": "Consultoria abril",
    "quantidade": 1,
    "valor_unitario": 650,
    "valor_total": 650,
    "operacao": "venda",
    "item_hash": "consultoria-abril-1",
    "data_venda": "2026-04-05"
  }'
```

Esperado: `200` com atualizacao do comprovante existente (mesmo `item_hash`).

10. Confirmar invalidacao de cache apos upsert

```bash
curl "http://localhost:5001/usuarios/1/saldo?mes=2026-04"
curl "http://localhost:5001/usuarios/1/comprovantes?mes=2026-04&modo=relatorio"
```

Esperado: os dados refletirem o valor mais recente do upsert, sem manter saldo/lista antigos em cache.

## Checklist de merge
- [ ] Validar `GET /usuarios/<id>/saldo` com `mes` valido e invalido.
- [ ] Validar `GET /usuarios/<id>/comprovantes` com `modo=relatorio|gastos|vendas`.
- [ ] Validar erro `400` para `modo` invalido.
- [ ] Validar `POST /usuarios/<id>/comprovantes` com payload valido para `venda` e `gasto`.
- [ ] Validar comportamento de upsert por `item_hash` (insert e update).
- [ ] Confirmar invalidacao de cache por prefixo para `saldo` e `comprovantes` apos escrita.
- [ ] Confirmar documentacao alinhada com o fluxo real de execucao local.
