### PR TITLE
feat: implementa endpoints de agendamentos (listagem semanal, criação e atualização de status) com validações e correção de retorno por usuário

### DIFF
--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -6,9 +6,6 @@ Queries de agendamentos — funções puras que recebem conn + parâmetros e ret
 
 
 def list_semana(conn, usuario_id: int) -> list[dict]:
-    # TODO: implementar
-    # Executar SELECT para a semana atual (segunda a sábado) no fuso America/Sao_Paulo
-    # Retornar lista de dicts ordenada por data_compromisso, hora_compromisso
     sql = """
         SELECT
             id,
@@ -32,11 +29,31 @@ def list_semana(conn, usuario_id: int) -> list[dict]:
 
 
 def create(conn, usuario_id: int, data: dict) -> dict:
-    # TODO: implementar
-    # Executar INSERT RETURNING
-    # Converter data_compromisso via TO_DATE(%(data_compromisso)s, 'DD/MM/YYYY')
-    # Retornar dict com dados do agendamento criado
-    pass
+    params ={
+        "usuario_id": usuario_id,
+        "nome_compromisso": data.get("nome_compromisso"),    
+        "data_compromisso": data.get("data_compromisso"),
+        "hora_compromisso": data.get("hora_compromisso")
+    }
+    
+    sql = """
+        INSERT INTO public.agendamentos (
+            usuario_id, nome_compromisso, data_compromisso,
+            hora_compromisso, status, data_criacao, data_modificacao)
+        VALUES (
+            %(usuario_id)s,
+            %(nome_compromisso)s,
+            %(data_compromisso)s::date,
+            %(hora_compromisso)s::time,
+            'confirmado',
+            NOW(), NOW())
+        RETURNING id, nome_compromisso, data_compromisso, hora_compromisso, status;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, params)
+        row = cursor.fetchone()
+        return dict(row)
 
 
 def update_status(conn, agendamento_id: int, usuario_id: int, status: str) -> dict | None:

--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -1,3 +1,5 @@
+from psycopg2.extras import RealDictCursor
+
 """
 Queries de agendamentos — funções puras que recebem conn + parâmetros e retornam rows.
 """
@@ -7,7 +9,26 @@ def list_semana(conn, usuario_id: int) -> list[dict]:
     # TODO: implementar
     # Executar SELECT para a semana atual (segunda a sábado) no fuso America/Sao_Paulo
     # Retornar lista de dicts ordenada por data_compromisso, hora_compromisso
-    pass
+    sql = """
+        SELECT
+            id,
+            nome_compromisso,
+            data_compromisso,
+            TO_CHAR(hora_compromisso, 'HH24:MI') AS hora_compromisso,
+            status
+        FROM public.agendamentos
+        WHERE usuario_id = %(usuario_id)s
+            AND status IN ('pendente', 'confirmado', 'agendado')
+            AND data_compromisso >= date_trunc('week', CURRENT_DATE AT TIME ZONE 'America/Sao_Paulo')::date
+            AND data_compromisso <  date_trunc('week', CURRENT_DATE AT TIME ZONE 'America/Sao_Paulo')::date + 7
+        ORDER BY data_compromisso, hora_compromisso;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"usuario_id": usuario_id})
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+    
 
 
 def create(conn, usuario_id: int, data: dict) -> dict:

--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -57,7 +57,15 @@ def create(conn, usuario_id: int, data: dict) -> dict:
 
 
 def update_status(conn, agendamento_id: int, usuario_id: int, status: str) -> dict | None:
-    # TODO: implementar
-    # Executar UPDATE status WHERE id AND usuario_id RETURNING
-    # Retornar dict ou None se não encontrado
-    pass
+    sql = """
+        UPDATE public.agendamentos
+        SET status = %(status)s, data_modificacao = NOW()
+        WHERE id = %(agendamento_id)s
+            AND usuario_id = %(usuario_id)s
+        RETURNING id, nome_compromisso, status;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"agendamento_id": agendamento_id, "usuario_id": usuario_id, "status":status})
+        row = cursor.fetchone()
+        return dict(row) if row else None

--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -1,8 +1,7 @@
-from psycopg2.extras import RealDictCursor
-
 """
 Queries de agendamentos — funções puras que recebem conn + parâmetros e retornam rows.
 """
+from psycopg2.extras import RealDictCursor
 
 
 def list_semana(conn, usuario_id: int) -> list[dict]:

--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -16,8 +16,8 @@ def list_semana(conn, usuario_id: int) -> list[dict]:
         FROM public.agendamentos
         WHERE usuario_id = %(usuario_id)s
             AND status IN ('pendente', 'confirmado', 'agendado')
-            AND data_compromisso >= date_trunc('week', CURRENT_DATE AT TIME ZONE 'America/Sao_Paulo')::date
-            AND data_compromisso <  date_trunc('week', CURRENT_DATE AT TIME ZONE 'America/Sao_Paulo')::date + 7
+            AND data_compromisso >= date_trunc('week', NOW() AT TIME ZONE 'America/Sao_Paulo')::date
+            AND data_compromisso <  date_trunc('week', NOW() AT TIME ZONE 'America/Sao_Paulo')::date + INTERVAL '7 day'
         ORDER BY data_compromisso, hora_compromisso;
     """
     

--- a/src/queries/comprovantes.py
+++ b/src/queries/comprovantes.py
@@ -1,8 +1,7 @@
-from psycopg2.extras import RealDictCursor
-
 """
 Queries de comprovantes — funções puras que recebem conn + parâmetros e retornam rows.
 """
+from psycopg2.extras import RealDictCursor
 
 
 def get_saldo(conn, usuario_id: int, mes: str) -> dict:

--- a/src/queries/usuarios.py
+++ b/src/queries/usuarios.py
@@ -1,9 +1,8 @@
-from psycopg2.extras import RealDictCursor
-
 """
 Queries de usuários — funções puras que recebem conn + parâmetros e retornam rows.
 Nenhuma lógica HTTP ou de cache aqui.
 """
+from psycopg2.extras import RealDictCursor
 
 
 def find_by_telefone(conn, telefone: str) -> dict | None:

--- a/src/queries/usuarios.py
+++ b/src/queries/usuarios.py
@@ -6,8 +6,6 @@ from psycopg2.extras import RealDictCursor
 
 
 def find_by_telefone(conn, telefone: str) -> dict | None:
-    # TODO: implementar
-    # Executar SELECT por numero_telefone, retornar dict ou None
     sql = """
         SELECT
             id, numero_telefone, nome, razao_social, email,
@@ -29,9 +27,6 @@ def find_by_telefone(conn, telefone: str) -> dict | None:
 
 
 def upsert(conn, numero_telefone: str, nome: str, razao_social: str) -> dict:
-    # TODO: implementar
-    # Executar CTE: existing_user + inserted_user (evita race condition)
-    # Retornar dict com dados do usuário (existente ou recém-criado)
     sql = """
         WITH existing_user AS (
         SELECT * FROM public.usuarios
@@ -68,9 +63,6 @@ def upsert(conn, numero_telefone: str, nome: str, razao_social: str) -> dict:
 
 
 def update(conn, usuario_id: int, fields: dict) -> dict | None:
-    # TODO: implementar
-    # Executar UPDATE com COALESCE para campos permitidos
-    # Retornar dict com dados atualizados ou None se não encontrado
     sql = """
         UPDATE public.usuarios
         SET

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -1,12 +1,11 @@
-from datetime import date, datetime
-from zoneinfo import ZoneInfo
+from datetime import date
 
 from flask import Blueprint, request
 
 from src.db import get_db_conn
 from src.cache import cache_get, cache_invalidate_prefix, cache_set
 from src.config import Config
-from src.utils.validators import require_fields, validate_agendamento_payload, validate_semana_agendamento
+from src.utils.validators import validade_status_agendamento, validate_agendamento_payload, validate_semana_agendamento
 import src.queries.agendamentos as q
 from src.utils.api_response import fail, ok
 
@@ -51,9 +50,18 @@ def create_agendamento(usuario_id: int):
     "/usuarios/<int:usuario_id>/agendamentos/<int:agendamento_id>", methods=["PUT"]
 )
 def update_agendamento(usuario_id: int, agendamento_id: int):
-    # TODO: implementar
-    # 1. validar body (status obrigatório)
-    # 2. chamar q.update_status(conn, agendamento_id, usuario_id, status)
-    # 3. invalidar cache 'agendamentos:{usuario_id}:*'
-    # 4. retornar 200 com dados atualizados ou 404
-    pass
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+    
+    status = validade_status_agendamento(body.get("status"))
+    
+    with get_db_conn() as conn:
+        agendamento = q.update_status(conn, agendamento_id, usuario_id, status)
+        
+        if agendamento is None:
+            return fail("agendamento_nao_encontrado", f"o agendamento com id {agendamento_id} para o usuário informado não foi encontrado", status_code=404)
+        
+        cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
+        
+        return ok(200, agendamento)

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -1,24 +1,33 @@
-from flask import Blueprint, request, jsonify
+from datetime import date
+
+from flask import Blueprint, request
 
 from src.db import get_db_conn
 from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
-from src.utils.validators import require_fields
+from src.utils.validators import require_fields, validate_semana_agendamento
 import src.queries.agendamentos as q
+from src.utils.api_response import ok
 
 agendamentos_bp = Blueprint("agendamentos", __name__)
 
 
 @agendamentos_bp.route("/usuarios/<int:usuario_id>/agendamentos", methods=["GET"])
 def list_agendamentos(usuario_id: int):
-    # TODO: implementar
-    # 1. extrair ?semana=atual (por ora apenas "atual" suportado)
-    # 2. calcular semana ISO atual
-    # 3. checar cache 'agendamentos:{usuario_id}:{semana_iso}'
-    # 4. chamar q.list_semana(conn, usuario_id)
-    # 5. armazenar no cache com TTL CACHE_TTL_AGENDAMENTOS
-    # 6. retornar lista de agendamentos
-    pass
+    semana = validate_semana_agendamento(request.args.get("semana"))
+    iso = date.today().isocalendar()
+    semana_iso = f"{iso.year}-W{iso.week:02d}"
+    
+    agendamentos = cache_get("agendamentos", f"{usuario_id}:{semana_iso}")
+    if agendamentos:
+        return ok(200, agendamentos) 
+    
+    with get_db_conn() as conn:
+        agendamentos = q.list_semana(conn, usuario_id)
+        
+        cache_set("agendamentos", f"{usuario_id}:{semana_iso}", agendamentos, Config.CACHE_TTL_AGENDAMENTOS)
+        
+        return ok(200, agendamentos)
 
 
 @agendamentos_bp.route("/usuarios/<int:usuario_id>/agendamentos", methods=["POST"])

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -1,13 +1,14 @@
-from datetime import date
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
 
 from flask import Blueprint, request
 
 from src.db import get_db_conn
-from src.cache import cache_get, cache_set, cache_invalidate
+from src.cache import cache_get, cache_invalidate_prefix, cache_set
 from src.config import Config
-from src.utils.validators import require_fields, validate_semana_agendamento
+from src.utils.validators import require_fields, validate_agendamento_payload, validate_semana_agendamento
 import src.queries.agendamentos as q
-from src.utils.api_response import ok
+from src.utils.api_response import fail, ok
 
 agendamentos_bp = Blueprint("agendamentos", __name__)
 
@@ -32,12 +33,18 @@ def list_agendamentos(usuario_id: int):
 
 @agendamentos_bp.route("/usuarios/<int:usuario_id>/agendamentos", methods=["POST"])
 def create_agendamento(usuario_id: int):
-    # TODO: implementar
-    # 1. validar body (nome_compromisso, data_compromisso, hora_compromisso)
-    # 2. chamar q.create(conn, usuario_id, body)
-    # 3. invalidar cache 'agendamentos:{usuario_id}:*'
-    # 4. retornar 201 com dados do agendamento criado
-    pass
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+    
+    body = validate_agendamento_payload(body)
+    
+    with get_db_conn() as conn:
+        agendamento = q.create(conn, usuario_id, body)
+        
+        cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
+        
+        return agendamento
 
 
 @agendamentos_bp.route(

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -5,7 +5,7 @@ from flask import Blueprint, request
 from src.db import get_db_conn
 from src.cache import cache_get, cache_invalidate_prefix, cache_set
 from src.config import Config
-from src.utils.validators import validade_status_agendamento, validate_agendamento_payload, validate_semana_agendamento
+from src.utils.validators import validate_status_agendamento, validate_agendamento_payload, validate_semana_agendamento
 import src.queries.agendamentos as q
 from src.utils.api_response import fail, ok
 
@@ -14,7 +14,7 @@ agendamentos_bp = Blueprint("agendamentos", __name__)
 
 @agendamentos_bp.route("/usuarios/<int:usuario_id>/agendamentos", methods=["GET"])
 def list_agendamentos(usuario_id: int):
-    semana = validate_semana_agendamento(request.args.get("semana"))
+    validate_semana_agendamento(request.args.get("semana"))
     iso = date.today().isocalendar()
     semana_iso = f"{iso.year}-W{iso.week:02d}"
     
@@ -43,7 +43,7 @@ def create_agendamento(usuario_id: int):
         
         cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
         
-        return agendamento
+        return ok(200 ,agendamento)
 
 
 @agendamentos_bp.route(
@@ -54,7 +54,7 @@ def update_agendamento(usuario_id: int, agendamento_id: int):
     if not isinstance(body, dict):
         return fail("body_invalido", "JSON inválido ou ausente", 400)
     
-    status = validade_status_agendamento(body.get("status"))
+    status = validate_status_agendamento(body.get("status"))
     
     with get_db_conn() as conn:
         agendamento = q.update_status(conn, agendamento_id, usuario_id, status)

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -43,7 +43,7 @@ def create_agendamento(usuario_id: int):
         
         cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
         
-        return ok(200 ,agendamento)
+        return ok(201 ,agendamento)
 
 
 @agendamentos_bp.route(

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -49,12 +49,6 @@ def create_usuario():
 
 @usuarios_bp.route("/usuarios/<int:usuario_id>", methods=["PUT"])
 def update_usuario(usuario_id: int):
-    # TODO: implementar
-    # 1. validar body (pelo menos um campo permitido presente)
-    # 2. chamar q.update(conn, usuario_id, body)
-    # 3. invalidar cache 'usuario:{telefone}' e 'usuario:id:{id}'
-    # 4. retornar 200 com dados atualizados ou 404
-    
     body = request.get_json(silent=True)
     if not isinstance(body, dict):
         return fail("body_invalido", "JSON inválido ou ausente", 400)

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 import re
-import stat
 from typing import Final
 from zoneinfo import ZoneInfo
 from flask import abort
@@ -125,38 +124,43 @@ def validate_semana_agendamento(semana: str) -> str:
 def validate_agendamento_payload(body: dict) -> dict:
     """Valida o corpo da requisição de create de um agendamento"""
     require_fields(body, "nome_compromisso", "data_compromisso", "hora_compromisso")
-    
-    if not body.get("nome_compromisso").strip():
-        return abort(400, description="o campo 'nome_compromisso' não deve ser vazio")
-    
+
+    nome_compromisso = str(body.get("nome_compromisso", "")).strip()
+    if not nome_compromisso:
+        abort(400, description="o campo 'nome_compromisso' não deve ser vazio")
+
     tz = ZoneInfo("America/Sao_Paulo")
 
     try:
-        data_compromisso = date.fromisoformat(body.get("data_compromisso"))
+        data_compromisso = date.fromisoformat(str(body.get("data_compromisso", "")).strip())
     except (TypeError, ValueError):
-        return abort(400, description="o campo 'data_compromisso' deve estar no formato YYYY-MM-DD")
-    
+        abort(400, description="o campo 'data_compromisso' deve estar no formato YYYY-MM-DD")
+
     try:
-        hora_compromisso = datetime.strptime(body.get("hora_compromisso"), "%H:%M").time()
-    except ValueError:
-        return abort(400, "o campo 'hora_compromisso' deve estar no formato HH:MM")
+        hora_compromisso = datetime.strptime(str(body.get("hora_compromisso", "")).strip(), "%H:%M").time()
+    except (TypeError, ValueError):
+        abort(400, "o campo 'hora_compromisso' deve estar no formato HH:MM")
 
     agora = datetime.now(tz)
     hoje = agora.date()
 
     if data_compromisso < hoje:
-        return abort(400, "não é permitido agendar uma data no passado")
+        abort(400, "não é permitido agendar uma data no passado")
 
     if data_compromisso == hoje and hora_compromisso <= agora.time():
-        return abort(400, "não é permitido agendar um horário no passado")
-    
+        abort(400, "não é permitido agendar um horário no passado")
+
+    body["nome_compromisso"] = nome_compromisso
+    body["data_compromisso"] = data_compromisso.isoformat()
+    body["hora_compromisso"] = hora_compromisso.strftime("%H:%M")
+
     return body
 
 
-def validade_status_agendamento(status: str) -> str:
+def validate_status_agendamento(status: str) -> str:
     """Valida se o status informado para o agendamento é correto"""
     if not status:
-        return abort(400, description="o campo 'status' não pode ser vazio")
+        abort(400, description="o campo 'status' não pode ser vazio")
     
     status = status.lower()
     

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -19,6 +19,10 @@ _OPERACAO_ALIASES: Final[dict[str, str]] = {
     "venda": "venda",
 }
 
+_SEMANA_ALIASES: Final[dict[str, str]] = {
+    "atual": "atual"
+}
+
 
 def require_fields(body: dict, *fields: str):
     """Aborta com 400 se algum campo obrigatório estiver ausente."""
@@ -54,6 +58,7 @@ def validate_modo(modo: str) -> str:
 
 
 def validate_comprovante_payload(body: dict) -> dict:
+    """Valida o corpo da requisição do upsert de um comprovante"""
     operacao_raw = str(body.get("operacao", "")).strip().lower()
     operacao = _OPERACAO_ALIASES.get(operacao_raw)
     if operacao not in _OPERACAO_ALIASES:
@@ -94,3 +99,15 @@ def validate_comprovante_payload(body: dict) -> dict:
     body["item"] = item
     body["item_hash"] = item_hash
     return body
+
+
+def validate_semana_agendamento(semana: str) -> str:
+    """Valida se a semana informada em agendamentos é correta"""
+    raw = (semana or "").strip().lower()
+    normalizado = _SEMANA_ALIASES.get(raw)
+
+    if normalizado is None:
+        permitidos = ", ".join(sorted(_SEMANA_ALIASES.keys()))
+        abort(400, description=f"parâmetro 'semana' inválido. Use: {permitidos}")
+
+    return normalizado

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,6 +1,8 @@
+from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 import re
 from typing import Final
+from zoneinfo import ZoneInfo
 from flask import abort
 
 
@@ -111,3 +113,34 @@ def validate_semana_agendamento(semana: str) -> str:
         abort(400, description=f"parâmetro 'semana' inválido. Use: {permitidos}")
 
     return normalizado
+
+
+def validate_agendamento_payload(body: dict) -> dict:
+    """Valida o corpo da requisição de create de um agendamento"""
+    require_fields(body, "nome_compromisso", "data_compromisso", "hora_compromisso")
+    
+    if not body.get("nome_compromisso").strip():
+        return abort(400, description="o campo 'nome_compromisso' não deve ser vazio")
+    
+    tz = ZoneInfo("America/Sao_Paulo")
+
+    try:
+        data_compromisso = date.fromisoformat(body.get("data_compromisso"))
+    except (TypeError, ValueError):
+        return abort(400, description="o campo 'data_compromisso' deve estar no formato YYYY-MM-DD")
+    
+    try:
+        hora_compromisso = datetime.strptime(body.get("hora_compromisso"), "%H:%M").time()
+    except ValueError:
+        return abort(400, "o campo 'hora_compromisso' deve estar no formato HH:MM")
+
+    agora = datetime.now(tz)
+    hoje = agora.date()
+
+    if data_compromisso < hoje:
+        return abort(400, "não é permitido agendar uma data no passado")
+
+    if data_compromisso == hoje and hora_compromisso <= agora.time():
+        return abort(400, "não é permitido agendar um horário no passado")
+    
+    return body

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 import re
+import stat
 from typing import Final
 from zoneinfo import ZoneInfo
 from flask import abort
@@ -23,6 +24,12 @@ _OPERACAO_ALIASES: Final[dict[str, str]] = {
 
 _SEMANA_ALIASES: Final[dict[str, str]] = {
     "atual": "atual"
+}
+
+_STATUS_AGENDAMENTO: Final[set[str]] = {
+    "pendente",
+    "confirmado",
+    "agendado"
 }
 
 
@@ -144,3 +151,17 @@ def validate_agendamento_payload(body: dict) -> dict:
         return abort(400, "não é permitido agendar um horário no passado")
     
     return body
+
+
+def validade_status_agendamento(status: str) -> str:
+    """Valida se o status informado para o agendamento é correto"""
+    if not status:
+        return abort(400, description="o campo 'status' não pode ser vazio")
+    
+    status = status.lower()
+    
+    if status not in _STATUS_AGENDAMENTO:
+        permitidos = ", ".join(sorted(_STATUS_AGENDAMENTO))
+        abort(400, description=f"o campo 'status' está inválido. Use: {permitidos}")
+        
+    return status       


### PR DESCRIPTION
## Contexto

Esta branch implementa os endpoints de agendamentos para listagem semanal, criacao e atualizacao de status, com validacoes de entrada e invalidacao de cache por prefixo.

Antes desta PR:

1. As rotas de agendamentos estavam com `TODO` e sem implementacao funcional.
2. Nao havia validacao dedicada para o parametro `semana` na listagem.
3. O corpo do endpoint de criacao de agendamento nao era validado com regras de data/hora.
4. A atualizacao de status de agendamento nao estava implementada de ponta a ponta (route + query + validate).
5. A listagem semanal podia nao retornar corretamente os agendamentos do usuario em alguns cenarios.

## O que foi alterado

### `src/routes/agendamentos.py` - implementacao das rotas

1. Implementado `GET /usuarios/<usuario_id>/agendamentos` com:
   - validacao de `semana` (atualmente suporta `atual`)
   - calculo da semana ISO atual
   - leitura de cache `agendamentos:{usuario_id}:{semana_iso}`
   - consulta em banco via query dedicada
   - escrita em cache com `Config.CACHE_TTL_AGENDAMENTOS`
2. Implementado `POST /usuarios/<usuario_id>/agendamentos` com:
   - validacao de body JSON
   - validacao de payload do agendamento
   - criacao em banco
   - invalidacao de cache por prefixo para `agendamentos:{usuario_id}:*`
3. Implementado `PUT /usuarios/<usuario_id>/agendamentos/<agendamento_id>` com:
   - validacao de body JSON
   - validacao do campo `status`
   - update em banco
   - retorno `404` quando o agendamento nao existe para o usuario informado
   - invalidacao de cache por prefixo apos alteracao

### `src/queries/agendamentos.py` - listagem, criacao e update

1. Implementada query `list_semana` com filtro por:
   - `usuario_id`
   - semana atual no fuso `America/Sao_Paulo`
   - status ativos (`pendente`, `confirmado`, `agendado`)
2. Implementada query `create` com `INSERT ... RETURNING` para criar agendamento.
3. Implementada query `update_status` com `UPDATE ... RETURNING` e retorno `None` quando nao encontra registro.
4. Corrigida a logica para retornar corretamente os agendamentos do usuario na listagem semanal.

### `src/utils/validators.py` - validacoes de agendamentos

1. Adicionado `validate_semana_agendamento` para validar `semana=atual`.
2. Adicionado `validate_agendamento_payload` com validacao de:
   - `nome_compromisso` obrigatorio e nao vazio
   - `data_compromisso` no formato `YYYY-MM-DD`
   - `hora_compromisso` no formato `HH:MM`
   - bloqueio de agendamento em data/hora passada (timezone `America/Sao_Paulo`)
3. Adicionado `validade_status_agendamento` para validar status permitidos em update.

## Como testar

### Pre-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src/app run --port 5001 --debug
```

2. Para evitar bloqueio por API key no dev local:

```bash
unset API_KEY
```

### Cenarios de validacao

1. Listar agendamentos da semana atual

```bash
curl "http://localhost:5001/usuarios/1/agendamentos?semana=atual"
```

Esperado: `200` com lista de agendamentos da semana atual.

2. Validar erro para parametro `semana` invalido

```bash
curl "http://localhost:5001/usuarios/1/agendamentos?semana=proxima"
```

Esperado: `400` informando valor permitido para `semana`.

3. Criar agendamento valido

```bash
curl -X POST "http://localhost:5001/usuarios/1/agendamentos" \
  -H "Content-Type: application/json" \
  -d '{
    "nome_compromisso": "Reuniao com fornecedor",
    "data_compromisso": "2026-04-10",
    "hora_compromisso": "14:30"
  }'
```

Esperado: criacao do agendamento com dados retornados pela API.

4. Validar erro ao criar com data no passado

```bash
curl -X POST "http://localhost:5001/usuarios/1/agendamentos" \
  -H "Content-Type: application/json" \
  -d '{
    "nome_compromisso": "Compromisso antigo",
    "data_compromisso": "2025-01-01",
    "hora_compromisso": "09:00"
  }'
```

Esperado: `400` com mensagem de data/horario no passado.

5. Atualizar status de agendamento existente

```bash
curl -X PUT "http://localhost:5001/usuarios/1/agendamentos/1" \
  -H "Content-Type: application/json" \
  -d '{"status": "agendado"}'
```

Esperado: `200` com agendamento atualizado.

6. Validar erro de status invalido

```bash
curl -X PUT "http://localhost:5001/usuarios/1/agendamentos/1" \
  -H "Content-Type: application/json" \
  -d '{"status": "cancelado"}'
```

Esperado: `400` indicando status permitidos.

7. Validar retorno para agendamento inexistente

```bash
curl -X PUT "http://localhost:5001/usuarios/1/agendamentos/999999" \
  -H "Content-Type: application/json" \
  -d '{"status": "confirmado"}'
```

Esperado: `404` para agendamento nao encontrado.

## Checklist de merge
- [ ] Validar listagem semanal com `semana=atual`.
- [ ] Confirmar erro `400` para parametro `semana` invalido.
- [ ] Validar criacao de agendamento com payload valido.
- [ ] Confirmar bloqueio de data/hora no passado no create.
- [ ] Validar update de status com valor permitido.
- [ ] Confirmar erro `400` para status invalido no update.
- [ ] Confirmar erro `404` ao atualizar agendamento inexistente.
- [ ] Confirmar invalidacao de cache por prefixo apos create e update.
- [ ] Confirmar documentacao alinhada com o fluxo real de desenvolvimento local.
