### PR TITLE
feat: implementa route, query e validator do endpoint de upsert de contas recorrentes

### DIFF
--- a/src/queries/contas.py
+++ b/src/queries/contas.py
@@ -1,12 +1,45 @@
 """
 Queries de contas recorrentes — funções puras que recebem conn + parâmetros e retornam rows.
 """
+from psycopg2.extras import RealDictCursor
 
 TIPOS_VALIDOS = {"aluguel", "internet", "luz", "agua", "boleto"}
 
 
 def upsert(conn, usuario_id: int, data: dict) -> dict:
-    # TODO: implementar
-    # Executar INSERT ... ON CONFLICT (usuario_id, tipo) WHERE tipo <> 'boleto' DO UPDATE
-    # Retornar dict com dados da conta
-    pass
+    params = {
+        "usuario_id": usuario_id,
+        "tipo": data.get("tipo"),
+        "descricao": data.get("descricao"),
+        "valor": data.get("valor"),
+        "dia_vencimento": data.get("dia_vencimento"),
+        "lembrete_ativo": data.get("lembrete_ativo", False),
+        "pix_chave": data.get("pix_chave"),
+    }
+
+    sql = """
+        INSERT INTO public.contas_recorrentes (
+            usuario_id, tipo, descricao, valor, dia_vencimento, lembrete_ativo, pix_chave)
+        VALUES (
+            %(usuario_id)s,
+            %(tipo)s,        -- 'aluguel' | 'internet' | 'luz' | 'agua' | 'boleto'
+            %(descricao)s,
+            %(valor)s,
+            %(dia_vencimento)s,
+            %(lembrete_ativo)s,
+            %(pix_chave)s)
+        ON CONFLICT (usuario_id, tipo) WHERE tipo <> 'boleto'
+        DO UPDATE SET
+            descricao      = EXCLUDED.descricao,
+            valor          = EXCLUDED.valor,
+            dia_vencimento = EXCLUDED.dia_vencimento,
+            lembrete_ativo = EXCLUDED.lembrete_ativo,
+            pix_chave      = EXCLUDED.pix_chave,
+            updated_at     = NOW()
+        RETURNING id, tipo, descricao, valor, dia_vencimento, lembrete_ativo;
+    """
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, params)
+        row = cursor.fetchone()
+        return dict(row)

--- a/src/routes/contas.py
+++ b/src/routes/contas.py
@@ -1,17 +1,21 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request
 
 from src.db import get_db_conn
-from src.utils.validators import require_fields
+from src.utils.validators import validate_conta_recorrente_payload
 import src.queries.contas as q
+from src.utils.api_response import fail, ok
 
 contas_bp = Blueprint("contas", __name__)
 
 
 @contas_bp.route("/usuarios/<int:usuario_id>/contas-recorrentes", methods=["POST"])
 def upsert_conta(usuario_id: int):
-    # TODO: implementar
-    # 1. validar body (tipo, descricao, valor, dia_vencimento)
-    # 2. validar tipo: 'aluguel' | 'internet' | 'luz' | 'agua' | 'boleto'
-    # 3. chamar q.upsert(conn, usuario_id, body)
-    # 4. retornar 200 com dados da conta (sem cache — dados raramente lidos pelo N8N diretamente)
-    pass
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+
+    body = validate_conta_recorrente_payload(body)
+
+    with get_db_conn() as conn:
+        conta = q.upsert(conn, usuario_id, body)
+        return ok(200, conta)

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -31,6 +31,14 @@ _STATUS_AGENDAMENTO: Final[set[str]] = {
     "agendado"
 }
 
+_TIPOS_CONTA_RECORRENTE: Final[set[str]] = {
+    "aluguel",
+    "internet",
+    "luz",
+    "agua",
+    "boleto",
+}
+
 
 def require_fields(body: dict, *fields: str):
     """Aborta com 400 se algum campo obrigatório estiver ausente."""
@@ -172,4 +180,42 @@ def validate_status_agendamento(status: str) -> str:
         permitidos = ", ".join(sorted(_STATUS_AGENDAMENTO))
         abort(400, description=f"o campo 'status' está inválido. Use: {permitidos}")
         
-    return status       
+    return status
+
+
+def validate_conta_recorrente_payload(body: dict) -> dict:
+    """Valida o corpo da requisição de upsert de conta recorrente."""
+    require_fields(body, "tipo", "descricao", "valor", "dia_vencimento")
+
+    tipo = str(body.get("tipo", "")).strip().lower()
+    if tipo not in _TIPOS_CONTA_RECORRENTE:
+        permitidos = ", ".join(sorted(_TIPOS_CONTA_RECORRENTE))
+        abort(400, description=f"o campo 'tipo' está inválido. Use: {permitidos}")
+
+    try:
+        dia_vencimento = int(body.get("dia_vencimento"))
+    except (TypeError, ValueError):
+        abort(400, description="o campo 'dia_vencimento' deve ser inteiro entre 1 e 31")
+
+    if dia_vencimento < 1 or dia_vencimento > 31:
+        abort(400, description="o campo 'dia_vencimento' deve ser inteiro entre 1 e 31")
+
+    lembrete_ativo_raw = body.get("lembrete_ativo", False)
+    if isinstance(lembrete_ativo_raw, bool):
+        lembrete_ativo = lembrete_ativo_raw
+    elif isinstance(lembrete_ativo_raw, str):
+        valor = lembrete_ativo_raw.strip().lower()
+        if valor in {"true", "1", "sim", "yes"}:
+            lembrete_ativo = True
+        elif valor in {"false", "0", "nao", "não", "no"}:
+            lembrete_ativo = False
+        else:
+            abort(400, description="o campo 'lembrete_ativo' deve ser booleano")
+    else:
+        abort(400, description="o campo 'lembrete_ativo' deve ser booleano")
+
+    body["tipo"] = tipo
+    body["dia_vencimento"] = dia_vencimento
+    body["lembrete_ativo"] = lembrete_ativo
+
+    return body


### PR DESCRIPTION
## Contexto

Esta branch implementa o endpoint de contas recorrentes com upsert, validacoes de entrada e regra de conflito parcial para evitar duplicidade por tipo (exceto boleto).

Antes desta PR:

1. A rota de contas recorrentes estava com `TODO` e sem implementacao funcional.
2. A query de contas recorrentes estava sem SQL de upsert.
3. Nao havia validacao dedicada para payload de conta recorrente.
4. O parsing de `lembrete_ativo` nao estava centralizado e podia causar comportamento inconsistente.

## O que foi alterado

### `src/routes/contas.py` - implementacao da rota

1. Implementado `POST /usuarios/<usuario_id>/contas-recorrentes` com:
   - validacao de body JSON
   - validacao de payload via funcao dedicada
   - chamada de query de upsert no banco
   - retorno `200` com os dados retornados pelo `RETURNING`
2. Mantido sem cache (alinhado ao fluxo do N8N para este caso de uso).

### `src/queries/contas.py` - upsert de contas recorrentes

1. Implementada query `upsert` com:
   - `INSERT INTO public.contas_recorrentes (...)`
   - `ON CONFLICT (usuario_id, tipo) WHERE tipo <> 'boleto'`
   - `DO UPDATE` para atualizar os campos editaveis
   - `updated_at = NOW()` na atualizacao
   - `RETURNING id, tipo, descricao, valor, dia_vencimento, lembrete_ativo`
2. Mantida lista de tipos validos para o dominio (`aluguel`, `internet`, `luz`, `agua`, `boleto`).

### `src/utils/validators.py` - validacao dedicada de conta recorrente

1. Adicionado `validate_conta_recorrente_payload` com validacao de:
   - campos obrigatorios: `tipo`, `descricao`, `valor`, `dia_vencimento`
   - tipo permitido: `aluguel`, `internet`, `luz`, `agua`, `boleto`
   - `dia_vencimento` inteiro entre `1` e `31`
   - `lembrete_ativo` booleano (incluindo parsing de string)
2. Normalizacao do payload para a camada de query (`tipo` em lowercase, `dia_vencimento` inteiro, `lembrete_ativo` booleano).

## Como testar

### Pre-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src/app run --port 5001 --debug
```

2. Para evitar bloqueio por API key no dev local:

```bash
unset API_KEY
```

### Cenarios de validacao

1. Criar conta recorrente de aluguel

```bash
curl -X POST "http://localhost:5001/usuarios/1/contas-recorrentes" \
  -H "Content-Type: application/json" \
  -d '{
    "tipo": "aluguel",
    "descricao": "Aluguel da sala comercial",
    "valor": 1800.00,
    "dia_vencimento": 10,
    "lembrete_ativo": true,
    "pix_chave": "financeiro@empresa.com"
  }'
```

Esperado: `200` com dados da conta recorrente.

2. Atualizar mesma conta (upsert por conflito em `usuario_id + tipo`)

```bash
curl -X POST "http://localhost:5001/usuarios/1/contas-recorrentes" \
  -H "Content-Type: application/json" \
  -d '{
    "tipo": "aluguel",
    "descricao": "Aluguel reajustado",
    "valor": 1900.00,
    "dia_vencimento": 12,
    "lembrete_ativo": true,
    "pix_chave": "financeiro@empresa.com"
  }'
```

Esperado: `200` atualizando o mesmo registro de `aluguel` para o usuario.

3. Criar multiplos boletos para o mesmo usuario

```bash
curl -X POST "http://localhost:5001/usuarios/1/contas-recorrentes" \
  -H "Content-Type: application/json" \
  -d '{
    "tipo": "boleto",
    "descricao": "Boleto fornecedor A",
    "valor": 249.90,
    "dia_vencimento": 5,
    "lembrete_ativo": false,
    "pix_chave": null
  }'
```

Executar novamente com outra descricao/valor.

Esperado: `200` em ambas as chamadas, com insercao de registros distintos para `boleto`.

4. Validar erro para `tipo` invalido

```bash
curl -X POST "http://localhost:5001/usuarios/1/contas-recorrentes" \
  -H "Content-Type: application/json" \
  -d '{
    "tipo": "telefone",
    "descricao": "Conta telefone",
    "valor": 120.00,
    "dia_vencimento": 15,
    "lembrete_ativo": true
  }'
```

Esperado: `400` indicando tipos permitidos.

5. Validar erro para `dia_vencimento` fora da faixa

```bash
curl -X POST "http://localhost:5001/usuarios/1/contas-recorrentes" \
  -H "Content-Type: application/json" \
  -d '{
    "tipo": "agua",
    "descricao": "Conta de agua",
    "valor": 90.00,
    "dia_vencimento": 35,
    "lembrete_ativo": true
  }'
```

Esperado: `400` informando faixa valida de `dia_vencimento`.

6. Validar erro para body invalido/ausente

```bash
curl -X POST "http://localhost:5001/usuarios/1/contas-recorrentes" \
  -H "Content-Type: application/json" \
  -d '[]'
```

Esperado: `400` com `body_invalido`.

## Checklist de merge
- [ ] Validar criacao de conta recorrente com payload valido.
- [ ] Confirmar upsert para tipos unicos (`aluguel`, `internet`, `luz`, `agua`).
- [ ] Confirmar que `boleto` permite multiplos registros para o mesmo usuario.
- [ ] Validar erro `400` para `tipo` invalido.
- [ ] Validar erro `400` para `dia_vencimento` invalido.
- [ ] Validar erro `400` para body JSON invalido ou ausente.
- [ ] Confirmar retorno `200` com campos esperados do `RETURNING`.
- [ ] Confirmar documentacao alinhada com fluxo real de desenvolvimento local.
