### PR TITLE
feat: implementa todas as rotas de listas de compras e de itens

### DIFF
--- a/src/queries/listas.py
+++ b/src/queries/listas.py
@@ -23,11 +23,26 @@ def list_listas(conn, usuario_id: int) -> list[dict]:
 
 
 def list_itens(conn, lista_id: int, usuario_id: int) -> list[dict]:
-    # TODO: implementar
-    # Executar SELECT verificando ownership via EXISTS
-    # Retornar lista de dicts { id, nome_item, quantidade, preco_unitario, preco_total }
-    pass
-
+    sql = """
+        SELECT
+            il.id,
+            il.nome_item,
+            il.quantidade,
+            il.preco_unitario,
+            il.preco_total
+        FROM public.itens_lista il
+        WHERE il.lista_id = %(lista_id)s
+        AND EXISTS (
+            SELECT 1 FROM public.lista_compras lc
+            WHERE lc.id = %(lista_id)s AND lc.usuario_id = %(usuario_id)s)
+        ORDER BY il.nome_item;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"lista_id": lista_id, "usuario_id": usuario_id})
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+    
 
 def upsert_itens(conn, lista_id: int, usuario_id: int, itens: list[dict]) -> list[dict]:
     # TODO: implementar

--- a/src/queries/listas.py
+++ b/src/queries/listas.py
@@ -80,7 +80,21 @@ def upsert_itens(conn, lista_id: int, usuario_id: int, itens: list[dict]) -> lis
 
 
 def delete_itens(conn, lista_id: int, usuario_id: int, nomes: list[str]) -> list[str]:
-    # TODO: implementar
-    # Executar DELETE WHERE nome_item = ANY e ownership via EXISTS
-    # Retornar lista de nomes removidos
-    pass
+    sql = """
+        WITH deleted AS (
+            DELETE FROM public.itens_lista
+            WHERE lista_id = %(lista_id)s
+              AND LOWER(TRIM(nome_item)) = ANY(%(nomes)s)
+              AND EXISTS (
+                SELECT 1 FROM public.lista_compras lc
+                WHERE lc.id = %(lista_id)s AND lc.usuario_id = %(usuario_id)s)
+            RETURNING nome_item
+        )
+        SELECT COALESCE(array_agg(nome_item), ARRAY[]::text[]) AS removidos
+        FROM deleted;
+    """
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"lista_id": lista_id, "usuario_id": usuario_id, "nomes": nomes})
+        row = cursor.fetchone()
+        return list(row["removidos"]) if row and row["removidos"] else []

--- a/src/queries/listas.py
+++ b/src/queries/listas.py
@@ -1,13 +1,25 @@
 """
 Queries de listas de compras — funções puras que recebem conn + parâmetros e retornam rows.
 """
+from psycopg2.extras import RealDictCursor
 
 
 def list_listas(conn, usuario_id: int) -> list[dict]:
-    # TODO: implementar
-    # Executar SELECT lc + COUNT itens LEFT JOIN
-    # Retornar lista de dicts { id, nome_lista, total_itens }
-    pass
+    sql = """
+        SELECT
+            lc.id,
+            lc.nome_lista,
+            COUNT(il.id) AS total_itens
+        FROM public.lista_compras lc
+        LEFT JOIN public.itens_lista il ON lc.id = il.lista_id
+        WHERE lc.usuario_id = %(usuario_id)s
+        GROUP BY lc.id, lc.nome_lista
+        ORDER BY lc.data_atualizacao DESC;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"usuario_id": usuario_id})
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
 
 
 def list_itens(conn, lista_id: int, usuario_id: int) -> list[dict]:

--- a/src/queries/listas.py
+++ b/src/queries/listas.py
@@ -1,6 +1,8 @@
 """
 Queries de listas de compras — funções puras que recebem conn + parâmetros e retornam rows.
 """
+import json
+
 from psycopg2.extras import RealDictCursor
 
 
@@ -45,10 +47,36 @@ def list_itens(conn, lista_id: int, usuario_id: int) -> list[dict]:
     
 
 def upsert_itens(conn, lista_id: int, usuario_id: int, itens: list[dict]) -> list[dict]:
-    # TODO: implementar
-    # Executar INSERT ... ON CONFLICT (lista_id, nome_item) DO UPDATE via json_array_elements
-    # Retornar lista de dicts com itens inseridos/atualizados
-    pass
+    sql = """
+        INSERT INTO public.itens_lista (lista_id, nome_item, quantidade, preco_unitario)
+        SELECT
+            %(lista_id)s,
+            LOWER(TRIM(item->>'nome_item')),
+            COALESCE(NULLIF(TRIM(item->>'quantidade'), ''), '1')::numeric,
+            COALESCE(NULLIF(TRIM(item->>'preco_unitario'), ''), '0')::numeric
+        FROM json_array_elements(%(itens)s::json) AS item
+        WHERE EXISTS (
+            SELECT 1
+            FROM public.lista_compras lc
+            WHERE lc.id = %(lista_id)s AND lc.usuario_id = %(usuario_id)s
+        )
+        ON CONFLICT (lista_id, nome_item)
+        DO UPDATE SET
+            quantidade     = EXCLUDED.quantidade,
+            preco_unitario = EXCLUDED.preco_unitario
+        RETURNING nome_item, quantidade, preco_unitario;
+    """
+
+    params = {
+        "lista_id": lista_id,
+        "usuario_id": usuario_id,
+        "itens": json.dumps(itens),
+    }
+
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
 
 
 def delete_itens(conn, lista_id: int, usuario_id: int, nomes: list[str]) -> list[str]:

--- a/src/routes/listas.py
+++ b/src/routes/listas.py
@@ -5,18 +5,23 @@ from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
 from src.utils.validators import require_fields
 import src.queries.listas as q
+from src.utils.api_response import ok
 
 listas_bp = Blueprint("listas", __name__)
 
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas", methods=["GET"])
 def list_listas(usuario_id: int):
-    # TODO: implementar
-    # 1. checar cache 'listas:{usuario_id}'
-    # 2. chamar q.list_listas(conn, usuario_id)
-    # 3. armazenar no cache com TTL CACHE_TTL_LISTAS
-    # 4. retornar lista com id, nome_lista, total_itens
-    pass
+    listas = cache_get("listas", usuario_id)
+    if listas:
+        return ok(200, listas)
+    
+    with get_db_conn() as conn:
+        listas = q.list_listas(conn, usuario_id)
+        
+        cache_set("listas", usuario_id, listas, Config.CACHE_TTL_LISTAS)
+        
+        return ok(200, listas)
 
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas/<int:lista_id>/itens", methods=["GET"])

--- a/src/routes/listas.py
+++ b/src/routes/listas.py
@@ -26,12 +26,16 @@ def list_listas(usuario_id: int):
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas/<int:lista_id>/itens", methods=["GET"])
 def list_itens(usuario_id: int, lista_id: int):
-    # TODO: implementar
-    # 1. checar cache 'itens_lista:{lista_id}'
-    # 2. chamar q.list_itens(conn, lista_id, usuario_id)
-    # 3. armazenar no cache com TTL CACHE_TTL_LISTAS
-    # 4. retornar lista de itens
-    pass
+    itens_lista = cache_get("itens_lista", lista_id)
+    if itens_lista:
+        return ok(200, itens_lista)
+    
+    with get_db_conn() as conn:
+        itens_lista = q.list_itens(conn, lista_id, usuario_id)
+        
+        cache_set("itens_lista", lista_id, itens_lista, Config.CACHE_TTL_LISTAS)
+        
+        return ok(200, itens_lista)
 
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas/<int:lista_id>/itens", methods=["POST"])

--- a/src/routes/listas.py
+++ b/src/routes/listas.py
@@ -3,7 +3,10 @@ from flask import Blueprint, request
 from src.db import get_db_conn
 from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
-from src.utils.validators import validate_lista_itens_payload
+from src.utils.validators import (
+    validate_lista_delete_itens_payload,
+    validate_lista_itens_payload,
+)
 import src.queries.listas as q
 from src.utils.api_response import fail, ok
 
@@ -56,9 +59,15 @@ def upsert_itens(usuario_id: int, lista_id: int):
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas/<int:lista_id>/itens", methods=["DELETE"])
 def delete_itens(usuario_id: int, lista_id: int):
-    # TODO: implementar
-    # 1. validar body (array 'nomes' com pelo menos um elemento)
-    # 2. chamar q.delete_itens(conn, lista_id, usuario_id, nomes)
-    # 3. invalidar cache 'itens_lista:{lista_id}'
-    # 4. retornar { removidos: [...] }
-    pass
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+
+    nomes = validate_lista_delete_itens_payload(body)
+
+    with get_db_conn() as conn:
+        removidos = q.delete_itens(conn, lista_id, usuario_id, nomes)
+
+        cache_invalidate("itens_lista", lista_id)
+
+        return ok(200, {"removidos": removidos})

--- a/src/routes/listas.py
+++ b/src/routes/listas.py
@@ -1,11 +1,11 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request
 
 from src.db import get_db_conn
 from src.cache import cache_get, cache_set, cache_invalidate
 from src.config import Config
-from src.utils.validators import require_fields
+from src.utils.validators import validate_lista_itens_payload
 import src.queries.listas as q
-from src.utils.api_response import ok
+from src.utils.api_response import fail, ok
 
 listas_bp = Blueprint("listas", __name__)
 
@@ -40,12 +40,18 @@ def list_itens(usuario_id: int, lista_id: int):
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas/<int:lista_id>/itens", methods=["POST"])
 def upsert_itens(usuario_id: int, lista_id: int):
-    # TODO: implementar
-    # 1. validar body (array 'itens' com pelo menos um elemento)
-    # 2. chamar q.upsert_itens(conn, lista_id, usuario_id, itens)
-    # 3. invalidar cache 'itens_lista:{lista_id}'
-    # 4. retornar itens inseridos/atualizados
-    pass
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+
+    itens_normalizados = validate_lista_itens_payload(body)
+
+    with get_db_conn() as conn:
+        itens_upsertados = q.upsert_itens(conn, lista_id, usuario_id, itens_normalizados)
+
+        cache_invalidate("itens_lista", lista_id)
+
+        return ok(200, itens_upsertados)
 
 
 @listas_bp.route("/usuarios/<int:usuario_id>/listas/<int:lista_id>/itens", methods=["DELETE"])

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -219,3 +219,29 @@ def validate_conta_recorrente_payload(body: dict) -> dict:
     body["lembrete_ativo"] = lembrete_ativo
 
     return body
+
+
+def validate_lista_itens_payload(body: dict) -> list[dict]:
+    """Valida payload de upsert de itens de lista e normaliza campos."""
+    itens = body.get("itens")
+    if not isinstance(itens, list) or not itens:
+        abort(400, description="o campo 'itens' deve ser um array com pelo menos um item")
+
+    itens_normalizados: list[dict] = []
+    for idx, item in enumerate(itens):
+        if not isinstance(item, dict):
+            abort(400, description=f"o item na posição {idx} deve ser um objeto JSON")
+
+        nome_item = str(item.get("nome_item", "")).strip()
+        if not nome_item:
+            abort(400, description=f"o campo 'nome_item' é obrigatório no item da posição {idx}")
+
+        itens_normalizados.append(
+            {
+                "nome_item": nome_item,
+                "quantidade": item.get("quantidade"),
+                "preco_unitario": item.get("preco_unitario"),
+            }
+        )
+
+    return itens_normalizados

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -245,3 +245,19 @@ def validate_lista_itens_payload(body: dict) -> list[dict]:
         )
 
     return itens_normalizados
+
+
+def validate_lista_delete_itens_payload(body: dict) -> list[str]:
+    """Valida payload de remoção de itens e normaliza nomes para busca."""
+    nomes = body.get("nomes")
+    if not isinstance(nomes, list) or not nomes:
+        abort(400, description="o campo 'nomes' deve ser um array com pelo menos um item")
+
+    nomes_normalizados: list[str] = []
+    for idx, nome in enumerate(nomes):
+        nome_normalizado = str(nome).strip().lower()
+        if not nome_normalizado:
+            abort(400, description=f"o item na posição {idx} do campo 'nomes' não pode ser vazio")
+        nomes_normalizados.append(nome_normalizado)
+
+    return nomes_normalizados


### PR DESCRIPTION
## Contexto

Esta branch implementa os endpoints de listas de compras para listagem de listas, listagem de itens, upsert de itens e remocao de itens especificos, com validacoes de entrada e invalidacao de cache por chave.

Antes desta PR:

1. O modulo de listas ainda nao tinha implementacao funcional completa para uso real pela API.
2. As operacoes principais de listas (listar listas, listar itens, inserir/atualizar itens e remover itens) nao estavam fechadas de ponta a ponta entre rota, validacao e query.
3. Parte do fluxo estava pendente com `TODO`, impedindo a conclusao do ciclo completo de manipulacao de itens da lista.
4. Nao havia consolidacao clara das regras de validacao de payload para manter comportamento consistente nas operacoes de escrita.
5. A estrategia de cache para leitura de itens e invalidacao apos escrita ainda precisava ser formalizada no fluxo implementado.
## O que foi alterado

### `src/routes/listas.py` - implementacao das rotas de listas

1. Mantido `GET /usuarios/<usuario_id>/listas` com:
   - leitura de cache `listas:{usuario_id}`
   - consulta em banco via query dedicada
   - escrita em cache com `Config.CACHE_TTL_LISTAS`
2. Mantido `GET /usuarios/<usuario_id>/listas/<lista_id>/itens` com:
   - leitura de cache `itens_lista:{lista_id}`
   - consulta em banco via query dedicada
   - escrita em cache com `Config.CACHE_TTL_LISTAS`
3. Mantido `POST /usuarios/<usuario_id>/listas/<lista_id>/itens` com:
   - validacao de body JSON
   - validacao de payload (`itens`)
   - upsert em banco
   - invalidacao de cache `itens_lista:{lista_id}`
4. Implementado `DELETE /usuarios/<usuario_id>/listas/<lista_id>/itens` com:
   - validacao de body JSON
   - validacao de payload (`nomes`)
   - remocao em banco por lista e usuario
   - invalidacao de cache `itens_lista:{lista_id}`
   - retorno padrao com `{ removidos: [...] }`

### `src/queries/listas.py` - queries de listas e itens

1. Mantida query `list_listas` com contagem de itens por lista.
2. Mantida query `list_itens` com filtro por:
   - `lista_id`
   - ownership por `usuario_id` via `EXISTS`
3. Mantida query `upsert_itens` com:
   - normalizacao via `LOWER(TRIM(...))`
   - `ON CONFLICT (lista_id, nome_item)` para update idempotente
4. Implementada query `delete_itens` com:
   - `DELETE` em lote com `LOWER(TRIM(nome_item)) = ANY(%(nomes)s)`
   - validacao de ownership por `usuario_id` via `EXISTS`
   - CTE `deleted` + `array_agg` para retorno dos nomes removidos
   - retorno `[]` quando nada for removido

### `src/utils/validators.py` - validacoes de payload de listas

1. Mantido `validate_lista_itens_payload` para upsert de itens.
2. Adicionado `validate_lista_delete_itens_payload` com validacao de:
   - campo `nomes` obrigatorio
   - `nomes` deve ser array com pelo menos um elemento
   - cada nome deve ser nao vazio
   - normalizacao de nomes com `trim + lower`

## Como testar

### Pre-requisito

1. Subir banco local:

```bash
docker compose up db -d
```

### Subir API local

1. Carregar env e iniciar Flask:

```bash
export $(cat .env.local | xargs) && flask --app src/app run --port 5001 --debug
```

2. Para evitar bloqueio por API key no dev local:

```bash
unset API_KEY
```

### Cenarios de validacao

1. Listar listas do usuario

```bash
curl "http://localhost:5001/usuarios/1/listas"
```

Esperado: `200` com listas do usuario.

2. Listar itens de uma lista

```bash
curl "http://localhost:5001/usuarios/1/listas/1/itens"
```

Esperado: `200` com itens da lista.

3. Upsert de itens da lista

```bash
curl -X POST "http://localhost:5001/usuarios/1/listas/1/itens" \
  -H "Content-Type: application/json" \
  -d '{
    "itens": [
      {"nome_item": "Leite", "quantidade": 2, "preco_unitario": 6.5},
      {"nome_item": "Pao", "quantidade": 1, "preco_unitario": 8.0}
    ]
  }'
```

Esperado: `200` com itens upsertados e cache de itens invalidado.

4. Validar erro de body invalido no upsert

```bash
curl -X POST "http://localhost:5001/usuarios/1/listas/1/itens" \
  -H "Content-Type: application/json" \
  -d '{"itens": []}'
```

Esperado: `400` informando que `itens` deve conter pelo menos um item.

5. Remover itens especificos da lista

```bash
curl -X DELETE "http://localhost:5001/usuarios/1/listas/1/itens" \
  -H "Content-Type: application/json" \
  -d '{"nomes": ["leite", "pao"]}'
```

Esperado: `200` com `{ "removidos": [ ... ] }` e cache `itens_lista:{lista_id}` invalidado.

6. Validar erro de payload invalido no delete

```bash
curl -X DELETE "http://localhost:5001/usuarios/1/listas/1/itens" \
  -H "Content-Type: application/json" \
  -d '{"nomes": []}'
```

Esperado: `400` informando que `nomes` deve conter pelo menos um item.

7. Validar delete sem correspondencias

```bash
curl -X DELETE "http://localhost:5001/usuarios/1/listas/1/itens" \
  -H "Content-Type: application/json" \
  -d '{"nomes": ["item-inexistente"]}'
```

Esperado: `200` com `{ "removidos": [] }`.

## Checklist de merge

- [ ] Validar listagem de listas por usuario.
- [ ] Validar listagem de itens por lista.
- [ ] Confirmar upsert de itens com payload valido.
- [ ] Confirmar erro `400` para payload invalido no upsert.
- [ ] Validar remocao de itens por nomes no endpoint DELETE.
- [ ] Confirmar erro `400` para payload invalido no delete.
- [ ] Confirmar retorno vazio quando nenhum item for removido.
- [ ] Confirmar invalidacao de cache `itens_lista:{lista_id}` apos POST e DELETE.
- [ ] Confirmar documentacao alinhada com o fluxo real de desenvolvimento local.
