### PR TITLE
feat: adiciona endpoints de criação e cancelamento de agendamentos recorrentes

### DIFF
--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -116,7 +116,7 @@ def cancel_all(conn, usuario_id: int) -> list[dict]:
         return [dict(row) for row in rows]
 
 
-def cancel_recurrence(conn, usuario_id: int, recorrencia_id: int) -> list[dict]:
+def cancel_recurrence(conn, usuario_id: int, recorrencia_id: str) -> list[dict]:
     """Cancela todos os agendamentos de uma série recorrente e retorna os itens afetados."""
     sql = """
         UPDATE public.agendamentos

--- a/src/queries/agendamentos.py
+++ b/src/queries/agendamentos.py
@@ -2,6 +2,7 @@
 Queries de agendamentos — funções puras que recebem conn + parâmetros e retornam rows.
 """
 from psycopg2.extras import RealDictCursor
+import uuid
 
 
 def list_agendamentos(conn, usuario_id: int) -> list[dict]:
@@ -111,5 +112,58 @@ def cancel_all(conn, usuario_id: int) -> list[dict]:
     
     with conn.cursor(cursor_factory=RealDictCursor) as cursor:
         cursor.execute(sql, {"usuario_id": usuario_id})
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+
+def cancel_recurrence(conn, usuario_id: int, recorrencia_id: int) -> list[dict]:
+    """Cancela todos os agendamentos de uma série recorrente e retorna os itens afetados."""
+    sql = """
+        UPDATE public.agendamentos
+        SET status = 'cancelado', data_modificacao = NOW()
+        WHERE usuario_id = %(usuario_id)s
+            AND recorrencia_id = %(recorrencia_id)s
+            AND status IN ('pendente', 'confirmado', 'agendado')
+        RETURNING nome_compromisso, data_compromisso, TO_CHAR(hora_compromisso, 'HH24:MI') AS hora_compromisso;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, {"usuario_id": usuario_id, "recorrencia_id": recorrencia_id})
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+
+def create_recurrence(conn, usuario_id: int, nome_compromisso: str, datas: list, hora_compromisso: str) -> list[dict]:
+    """Cria múltiplos agendamentos em série com o mesmo recorrencia_id em uma única transação."""
+    if not datas:
+        return []
+    
+    recorrencia_id = str(uuid.uuid4())
+    
+    # Construir INSERT com múltiplos VALUES
+    placeholders = []
+    params = {
+        "usuario_id": usuario_id,
+        "nome_compromisso": nome_compromisso,
+        "hora_compromisso": hora_compromisso,
+        "recorrencia_id": recorrencia_id,
+        "status": "confirmado",
+    }
+    
+    # Adicionar cada data como parâmetro
+    for i, data_compromisso in enumerate(datas):
+        params[f"data_{i}"] = data_compromisso
+        placeholders.append(f"(%(usuario_id)s, %(nome_compromisso)s, %(data_{i})s::date, %(hora_compromisso)s::time, %(status)s, %(recorrencia_id)s, NOW(), NOW())")
+    
+    sql = f"""
+        INSERT INTO public.agendamentos (
+            usuario_id, nome_compromisso, data_compromisso,
+            hora_compromisso, status, recorrencia_id, data_criacao, data_modificacao)
+        VALUES {', '.join(placeholders)}
+        RETURNING id, nome_compromisso, data_compromisso, TO_CHAR(hora_compromisso, 'HH24:MI') AS hora_compromisso, status, recorrencia_id;
+    """
+    
+    with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+        cursor.execute(sql, params)
         rows = cursor.fetchall()
         return [dict(row) for row in rows]

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -115,6 +115,9 @@ def cancel_recurrence(usuario_id: int, recorrencia_id: str):
     with get_db_conn() as conn:
         agendamentos_cancelados = q.cancel_recurrence(conn, usuario_id, recorrencia_id)
         
+        if not agendamentos_cancelados:
+            return fail("recorrencia_nao_encontrada", f"nenhuma recorrência com id {recorrencia_id} foi encontrada", status_code=404)
+        
         cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
         
         return ok(200, agendamentos_cancelados)

--- a/src/routes/agendamentos.py
+++ b/src/routes/agendamentos.py
@@ -3,7 +3,8 @@ from flask import Blueprint, request
 from src.db import get_db_conn
 from src.cache import cache_get, cache_invalidate_prefix, cache_set
 from src.config import Config
-from src.utils.validators import validate_agendamento_payload, validate_scope_agendamento, validate_update_agendamento_payload
+from src.utils.validators import validate_agendamento_payload, validate_scope_agendamento, validate_update_agendamento_payload, validate_recurrence_payload
+from src.utils.recurrence_generator import generate_recurrence_dates
 import src.queries.agendamentos as q
 from src.utils.api_response import fail, ok
 
@@ -43,6 +44,41 @@ def create_agendamento(usuario_id: int):
         return ok(201 ,agendamento)
 
 
+@agendamentos_bp.route("/usuarios/<int:usuario_id>/agendamentos/recorrentes", methods=["POST"])
+def create_recurrence(usuario_id: int):
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+    
+    validated_data = validate_recurrence_payload(body)
+    
+    try:
+        datas = generate_recurrence_dates(
+            validated_data["data_inicio"],
+            validated_data["frequencia"],
+            validated_data["dia_semana_ou_mes"],
+            validated_data["quantidade_meses"]
+        )
+    except ValueError as e:
+        return fail("recurrence_generation_error", str(e), 400)
+    
+    if not datas:
+        return fail("no_dates_generated", "Nenhuma data foi gerada para a recorrência", 400)
+    
+    with get_db_conn() as conn:
+        agendamentos = q.create_recurrence(
+            conn,
+            usuario_id,
+            validated_data["nome_compromisso"],
+            datas,
+            validated_data["hora_compromisso"]
+        )
+        
+        cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
+        
+        return ok(201, agendamentos)
+
+
 @agendamentos_bp.route(
     "/usuarios/<int:usuario_id>/agendamentos/<int:agendamento_id>", methods=["PUT"]
 )
@@ -68,6 +104,16 @@ def update_agendamento(usuario_id: int, agendamento_id: int):
 def cancel_all_agendamentos(usuario_id: int):
     with get_db_conn() as conn:
         agendamentos_cancelados = q.cancel_all(conn, usuario_id)
+        
+        cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
+        
+        return ok(200, agendamentos_cancelados)
+
+
+@agendamentos_bp.route("/usuarios/<int:usuario_id>/agendamentos/recorrencia/<string:recorrencia_id>", methods=["DELETE"])
+def cancel_recurrence(usuario_id: int, recorrencia_id: str):
+    with get_db_conn() as conn:
+        agendamentos_cancelados = q.cancel_recurrence(conn, usuario_id, recorrencia_id)
         
         cache_invalidate_prefix("agendamentos", f"{usuario_id}:")
         

--- a/src/utils/recurrence_generator.py
+++ b/src/utils/recurrence_generator.py
@@ -1,0 +1,209 @@
+"""
+Geração de datas para agendamentos recorrentes.
+"""
+from datetime import date, timedelta
+from typing import Final
+
+# Mapeamento de nomes em português para números de dia da semana (0=seg, 6=dom)
+_WEEKDAY_MAP: Final[dict[str, int]] = {
+    "seg": 0,
+    "ter": 1,
+    "qua": 2,
+    "qui": 3,
+    "sex": 4,
+    "sab": 5,
+    "dom": 6,
+}
+
+# Inverso para referência
+_WEEKDAY_REVERSE: Final[dict[int, str]] = {v: k for k, v in _WEEKDAY_MAP.items()}
+
+
+def generate_recurrence_dates(
+    data_inicio: date,
+    frequencia: str,
+    dia_semana_ou_mes: str,
+    quantidade_meses: int,
+) -> list[date]:
+    """
+    Gera lista de datas para uma série recorrente.
+
+    Args:
+        data_inicio: Data do primeiro agendamento
+        frequencia: 'semanal', 'quinzenal' ou 'mensal'
+        dia_semana_ou_mes: Dia da semana (seg, ter, qua, qui, sex, sab, dom) ou dia do mês (1-31)
+        quantidade_meses: Horizonte em meses (1-12)
+
+    Returns:
+        Lista de datas ordenadas
+
+    Raises:
+        ValueError: Se os parâmetros forem inválidos
+    """
+    if frequencia not in ("semanal", "quinzenal", "mensal"):
+        raise ValueError(f"frequencia inválida: {frequencia}")
+
+    if quantidade_meses < 1 or quantidade_meses > 12:
+        raise ValueError(f"quantidade_meses deve estar entre 1 e 12, recebido: {quantidade_meses}")
+
+    # Calcular data final (exatamente quantidade_meses meses depois)
+    end_month = data_inicio.month + quantidade_meses
+    end_year = data_inicio.year
+
+    # Ajustar ano e mês se necessário
+    if end_month > 12:
+        end_month -= 12
+        end_year += 1
+
+    # Data final é o último dia do mês anterior ao que seria quantidade_meses depois
+    import calendar
+    try:
+        # Tentar usar o mesmo dia da data_inicio
+        data_final = date(end_year, end_month, data_inicio.day)
+    except ValueError:
+        # Se o dia não existir neste mês, usar o último dia do mês
+        _, last_day = calendar.monthrange(end_year, end_month)
+        data_final = date(end_year, end_month, last_day)
+
+    datas = []
+
+    if frequencia == "semanal":
+        # Validar dia da semana
+        if dia_semana_ou_mes not in _WEEKDAY_MAP:
+            raise ValueError(f"dia_semana inválido: {dia_semana_ou_mes}. Esperado: seg, ter, qua, qui, sex, sab, dom")
+
+        target_weekday = _WEEKDAY_MAP[dia_semana_ou_mes]
+        current = data_inicio
+
+        # Avançar para o primeiro dia da semana correto
+        days_ahead = (target_weekday - current.weekday()) % 7
+        if days_ahead > 0:
+            current = current + timedelta(days=days_ahead)
+
+        while current <= data_final:
+            datas.append(current)
+            current = current + timedelta(weeks=1)
+
+    elif frequencia == "quinzenal":
+        # Validar dia da semana
+        if dia_semana_ou_mes not in _WEEKDAY_MAP:
+            raise ValueError(f"dia_semana inválido: {dia_semana_ou_mes}. Esperado: seg, ter, qua, qui, sex, sab, dom")
+
+        target_weekday = _WEEKDAY_MAP[dia_semana_ou_mes]
+        current = data_inicio
+
+        # Avançar para o primeiro dia da semana correto
+        days_ahead = (target_weekday - current.weekday()) % 7
+        if days_ahead > 0:
+            current = current + timedelta(days=days_ahead)
+
+        while current <= data_final:
+            datas.append(current)
+            current = current + timedelta(weeks=2)
+
+    elif frequencia == "mensal":
+        # Validar dia do mês
+        try:
+            dia_mes = int(dia_semana_ou_mes)
+        except ValueError:
+            raise ValueError(f"dia_semana_ou_mes deve ser um número para frequência 'mensal': {dia_semana_ou_mes}")
+
+        if dia_mes < 1 or dia_mes > 31:
+            raise ValueError(f"dia_mes deve estar entre 1 e 31, recebido: {dia_mes}")
+
+        year, month = data_inicio.year, data_inicio.month
+
+        while True:
+            # Tentar usar o dia especificado; se não existir, usar o último dia do mês
+            try:
+                current = date(year, month, dia_mes)
+            except ValueError:
+                import calendar
+                _, last_day = calendar.monthrange(year, month)
+                current = date(year, month, last_day)
+
+            if current > data_final:
+                break
+
+            datas.append(current)
+
+            # Próximo mês
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+
+    return sorted(datas)
+
+    datas = []
+
+    if frequencia == "semanal":
+        # Validar dia da semana
+        if dia_semana_ou_mes not in _WEEKDAY_MAP:
+            raise ValueError(f"dia_semana inválido: {dia_semana_ou_mes}. Esperado: seg, ter, qua, qui, sex, sab, dom")
+
+        target_weekday = _WEEKDAY_MAP[dia_semana_ou_mes]
+        current = data_inicio
+
+        # Avançar para o primeiro dia da semana correto
+        days_ahead = (target_weekday - current.weekday()) % 7
+        if days_ahead == 0 and current != data_inicio:
+            # Se já é o dia correto mas não é a data inicial, começar desse dia
+            pass
+        elif days_ahead > 0:
+            current = current + timedelta(days=days_ahead)
+
+        while current <= data_final:
+            datas.append(current)
+            current = current + timedelta(weeks=1)
+
+    elif frequencia == "quinzenal":
+        # Validar dia da semana
+        if dia_semana_ou_mes not in _WEEKDAY_MAP:
+            raise ValueError(f"dia_semana inválido: {dia_semana_ou_mes}. Esperado: seg, ter, qua, qui, sex, sab, dom")
+
+        target_weekday = _WEEKDAY_MAP[dia_semana_ou_mes]
+        current = data_inicio
+
+        # Avançar para o primeiro dia da semana correto
+        days_ahead = (target_weekday - current.weekday()) % 7
+        if days_ahead > 0:
+            current = current + timedelta(days=days_ahead)
+
+        while current <= data_final:
+            datas.append(current)
+            current = current + timedelta(weeks=2)
+
+    elif frequencia == "mensal":
+        # Validar dia do mês
+        try:
+            dia_mes = int(dia_semana_ou_mes)
+        except ValueError:
+            raise ValueError(f"dia_semana_ou_mes deve ser um número para frequência 'mensal': {dia_semana_ou_mes}")
+
+        if dia_mes < 1 or dia_mes > 31:
+            raise ValueError(f"dia_mes deve estar entre 1 e 31, recebido: {dia_mes}")
+
+        year, month = data_inicio.year, data_inicio.month
+
+        while True:
+            # Tentar usar o dia especificado; se não existir, usar o último dia do mês
+            try:
+                current = date(year, month, dia_mes)
+            except ValueError:
+                import calendar
+                _, last_day = calendar.monthrange(year, month)
+                current = date(year, month, last_day)
+
+            if current > data_final:
+                break
+
+            datas.append(current)
+
+            # Próximo mês
+            month += 1
+            if month > 12:
+                month = 1
+                year += 1
+
+    return sorted(datas)

--- a/src/utils/recurrence_generator.py
+++ b/src/utils/recurrence_generator.py
@@ -1,6 +1,7 @@
 """
 Geração de datas para agendamentos recorrentes.
 """
+import calendar
 from datetime import date, timedelta
 from typing import Final
 
@@ -14,9 +15,6 @@ _WEEKDAY_MAP: Final[dict[str, int]] = {
     "sab": 5,
     "dom": 6,
 }
-
-# Inverso para referência
-_WEEKDAY_REVERSE: Final[dict[int, str]] = {v: k for k, v in _WEEKDAY_MAP.items()}
 
 
 def generate_recurrence_dates(
@@ -56,7 +54,6 @@ def generate_recurrence_dates(
         end_year += 1
 
     # Data final é o último dia do mês anterior ao que seria quantidade_meses depois
-    import calendar
     try:
         # Tentar usar o mesmo dia da data_inicio
         data_final = date(end_year, end_month, data_inicio.day)
@@ -118,80 +115,6 @@ def generate_recurrence_dates(
             try:
                 current = date(year, month, dia_mes)
             except ValueError:
-                import calendar
-                _, last_day = calendar.monthrange(year, month)
-                current = date(year, month, last_day)
-
-            if current > data_final:
-                break
-
-            datas.append(current)
-
-            # Próximo mês
-            month += 1
-            if month > 12:
-                month = 1
-                year += 1
-
-    return sorted(datas)
-
-    datas = []
-
-    if frequencia == "semanal":
-        # Validar dia da semana
-        if dia_semana_ou_mes not in _WEEKDAY_MAP:
-            raise ValueError(f"dia_semana inválido: {dia_semana_ou_mes}. Esperado: seg, ter, qua, qui, sex, sab, dom")
-
-        target_weekday = _WEEKDAY_MAP[dia_semana_ou_mes]
-        current = data_inicio
-
-        # Avançar para o primeiro dia da semana correto
-        days_ahead = (target_weekday - current.weekday()) % 7
-        if days_ahead == 0 and current != data_inicio:
-            # Se já é o dia correto mas não é a data inicial, começar desse dia
-            pass
-        elif days_ahead > 0:
-            current = current + timedelta(days=days_ahead)
-
-        while current <= data_final:
-            datas.append(current)
-            current = current + timedelta(weeks=1)
-
-    elif frequencia == "quinzenal":
-        # Validar dia da semana
-        if dia_semana_ou_mes not in _WEEKDAY_MAP:
-            raise ValueError(f"dia_semana inválido: {dia_semana_ou_mes}. Esperado: seg, ter, qua, qui, sex, sab, dom")
-
-        target_weekday = _WEEKDAY_MAP[dia_semana_ou_mes]
-        current = data_inicio
-
-        # Avançar para o primeiro dia da semana correto
-        days_ahead = (target_weekday - current.weekday()) % 7
-        if days_ahead > 0:
-            current = current + timedelta(days=days_ahead)
-
-        while current <= data_final:
-            datas.append(current)
-            current = current + timedelta(weeks=2)
-
-    elif frequencia == "mensal":
-        # Validar dia do mês
-        try:
-            dia_mes = int(dia_semana_ou_mes)
-        except ValueError:
-            raise ValueError(f"dia_semana_ou_mes deve ser um número para frequência 'mensal': {dia_semana_ou_mes}")
-
-        if dia_mes < 1 or dia_mes > 31:
-            raise ValueError(f"dia_mes deve estar entre 1 e 31, recebido: {dia_mes}")
-
-        year, month = data_inicio.year, data_inicio.month
-
-        while True:
-            # Tentar usar o dia especificado; se não existir, usar o último dia do mês
-            try:
-                current = date(year, month, dia_mes)
-            except ValueError:
-                import calendar
                 _, last_day = calendar.monthrange(year, month)
                 current = date(year, month, last_day)
 

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -303,14 +303,14 @@ def validate_recurrence_payload(body: dict) -> dict:
     if quantidade_meses < 1 or quantidade_meses > 12:
         abort(400, description="o campo 'quantidade_meses' deve estar entre 1 e 12")
 
-    body["nome_compromisso"] = nome_compromisso
-    body["data_inicio"] = data_inicio
-    body["hora_compromisso"] = hora_compromisso.strftime("%H:%M")
-    body["frequencia"] = frequencia
-    body["dia_semana_ou_mes"] = dia_semana_ou_mes
-    body["quantidade_meses"] = quantidade_meses
-
-    return body
+    return {
+        "nome_compromisso": nome_compromisso,
+        "data_inicio": data_inicio,
+        "hora_compromisso": hora_compromisso.strftime("%H:%M"),
+        "frequencia": frequencia,
+        "dia_semana_ou_mes": dia_semana_ou_mes,
+        "quantidade_meses": quantidade_meses,
+    }
 
 
 def validate_conta_recorrente_payload(body: dict) -> dict:

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -249,6 +249,70 @@ def validate_update_agendamento_payload(body: dict) -> dict:
     return resultado
 
 
+def validate_recurrence_payload(body: dict) -> dict:
+    """Valida o corpo da requisição de criação de agendamento recorrente."""
+    require_fields(body, "nome_compromisso", "data_inicio", "hora_compromisso", "frequencia", "dia_semana_ou_mes", "quantidade_meses")
+
+    nome_compromisso = str(body.get("nome_compromisso", "")).strip()
+    if not nome_compromisso:
+        abort(400, description="o campo 'nome_compromisso' não deve ser vazio")
+
+    tz = ZoneInfo("America/Sao_Paulo")
+
+    try:
+        data_inicio = date.fromisoformat(str(body.get("data_inicio", "")).strip())
+    except (TypeError, ValueError):
+        abort(400, description="o campo 'data_inicio' deve estar no formato YYYY-MM-DD")
+
+    try:
+        hora_compromisso = datetime.strptime(str(body.get("hora_compromisso", "")).strip(), "%H:%M").time()
+    except (TypeError, ValueError):
+        abort(400, description="o campo 'hora_compromisso' deve estar no formato HH:MM")
+
+    agora = datetime.now(tz)
+    hoje = agora.date()
+
+    if data_inicio < hoje:
+        abort(400, description="o campo 'data_inicio' não pode estar no passado")
+
+    if data_inicio == hoje and hora_compromisso <= agora.time():
+        abort(400, description="não é permitido agendar um horário no passado")
+
+    frequencia = str(body.get("frequencia", "")).strip().lower()
+    if frequencia not in {"semanal", "quinzenal", "mensal"}:
+        abort(400, description="o campo 'frequencia' deve ser 'semanal', 'quinzenal' ou 'mensal'")
+
+    dia_semana_ou_mes = str(body.get("dia_semana_ou_mes", "")).strip().lower()
+    if frequencia in {"semanal", "quinzenal"}:
+        dias_validos = {"seg", "ter", "qua", "qui", "sex", "sab", "dom"}
+        if dia_semana_ou_mes not in dias_validos:
+            abort(400, description=f"para frequência '{frequencia}', 'dia_semana_ou_mes' deve ser um dia da semana: {', '.join(sorted(dias_validos))}")
+    else:  # mensal
+        try:
+            dia_mes = int(dia_semana_ou_mes)
+            if dia_mes < 1 or dia_mes > 31:
+                abort(400, description="para frequência 'mensal', 'dia_semana_ou_mes' deve ser um número entre 1 e 31")
+        except ValueError:
+            abort(400, description="para frequência 'mensal', 'dia_semana_ou_mes' deve ser um número entre 1 e 31")
+
+    try:
+        quantidade_meses = int(body.get("quantidade_meses"))
+    except (TypeError, ValueError):
+        abort(400, description="o campo 'quantidade_meses' deve ser um inteiro")
+
+    if quantidade_meses < 1 or quantidade_meses > 12:
+        abort(400, description="o campo 'quantidade_meses' deve estar entre 1 e 12")
+
+    body["nome_compromisso"] = nome_compromisso
+    body["data_inicio"] = data_inicio
+    body["hora_compromisso"] = hora_compromisso.strftime("%H:%M")
+    body["frequencia"] = frequencia
+    body["dia_semana_ou_mes"] = dia_semana_ou_mes
+    body["quantidade_meses"] = quantidade_meses
+
+    return body
+
+
 def validate_conta_recorrente_payload(body: dict) -> dict:
     """Valida o corpo da requisição de upsert de conta recorrente."""
     require_fields(body, "tipo", "descricao", "valor", "dia_vencimento")

--- a/tests/test_agendamentos.py
+++ b/tests/test_agendamentos.py
@@ -375,3 +375,255 @@ class TestCancelAllAgendamentos:
 
         assert resp.status_code == 200
         invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+
+
+class TestCancelRecurrence:
+    def test_cancela_agendamentos_recorrentes(self, client, mock_db_conn, mocker):
+        usuario_id = 1
+        recorrencia_id = 42
+        data_futura = (date.today() + timedelta(days=5)).isoformat()
+        agendamentos_cancelados = [
+            {
+                "nome_compromisso": "Reunião semanal",
+                "data_compromisso": data_futura,
+                "hora_compromisso": "10:00",
+            },
+            {
+                "nome_compromisso": "Reunião semanal",
+                "data_compromisso": (date.today() + timedelta(days=12)).isoformat(),
+                "hora_compromisso": "10:00",
+            },
+        ]
+        _, conn = mock_db_conn("src.routes.agendamentos.get_db_conn")
+
+        cancel_recurrence_mock = mocker.patch(
+            "src.routes.agendamentos.q.cancel_recurrence",
+            return_value=agendamentos_cancelados,
+        )
+        invalidate_prefix_mock = mocker.patch("src.routes.agendamentos.cache_invalidate_prefix")
+
+        resp = client.delete(f"/usuarios/{usuario_id}/agendamentos/recorrencia/{recorrencia_id}")
+
+        assert resp.status_code == 200
+        assert resp.get_json() == agendamentos_cancelados
+        cancel_recurrence_mock.assert_called_once_with(conn, usuario_id, recorrencia_id)
+        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+
+    def test_retorna_lista_vazia_sem_recorrencia(self, client, mock_db_conn, mocker):
+        usuario_id = 1
+        recorrencia_id = 999
+        _, conn = mock_db_conn("src.routes.agendamentos.get_db_conn")
+
+        cancel_recurrence_mock = mocker.patch(
+            "src.routes.agendamentos.q.cancel_recurrence",
+            return_value=[],
+        )
+        invalidate_prefix_mock = mocker.patch("src.routes.agendamentos.cache_invalidate_prefix")
+
+        resp = client.delete(f"/usuarios/{usuario_id}/agendamentos/recorrencia/{recorrencia_id}")
+
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+        cancel_recurrence_mock.assert_called_once_with(conn, usuario_id, recorrencia_id)
+        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+
+    def test_invalida_cache_apos_cancelamento_recorrencia(self, client, mock_db_conn, mocker):
+        usuario_id = 1
+        recorrencia_id = 42
+        agendamentos_cancelados = [
+            {
+                "nome_compromisso": "Reunião mensal",
+                "data_compromisso": (date.today() + timedelta(days=7)).isoformat(),
+                "hora_compromisso": "14:00",
+            },
+        ]
+        mock_db_conn("src.routes.agendamentos.get_db_conn")
+        mocker.patch("src.routes.agendamentos.q.cancel_recurrence", return_value=agendamentos_cancelados)
+        invalidate_prefix_mock = mocker.patch("src.routes.agendamentos.cache_invalidate_prefix")
+
+        resp = client.delete(f"/usuarios/{usuario_id}/agendamentos/recorrencia/{recorrencia_id}")
+
+        assert resp.status_code == 200
+        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+
+
+class TestCreateRecurrence:
+    def test_cria_agendamentos_recorrentes_semanais(self, client, mock_db_conn, mocker):
+        usuario_id = 1
+        data_inicio = (date.today() + timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião semanal",
+            "data_inicio": data_inicio,
+            "hora_compromisso": "10:00",
+            "frequencia": "semanal",
+            "dia_semana_ou_mes": "seg",
+            "quantidade_meses": 1,
+        }
+        agendamentos_fake = [
+            {
+                "id": 100,
+                "nome_compromisso": "Reunião semanal",
+                "data_compromisso": data_inicio,
+                "hora_compromisso": "10:00",
+                "status": "confirmado",
+                "recorrencia_id": "uuid-123",
+            },
+            {
+                "id": 101,
+                "nome_compromisso": "Reunião semanal",
+                "data_compromisso": (date.today() + timedelta(days=8)).isoformat(),
+                "hora_compromisso": "10:00",
+                "status": "confirmado",
+                "recorrencia_id": "uuid-123",
+            },
+        ]
+        _, conn = mock_db_conn("src.routes.agendamentos.get_db_conn")
+
+        create_recurrence_mock = mocker.patch(
+            "src.routes.agendamentos.q.create_recurrence",
+            return_value=agendamentos_fake,
+        )
+        invalidate_prefix_mock = mocker.patch("src.routes.agendamentos.cache_invalidate_prefix")
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 201
+        assert resp.get_json() == agendamentos_fake
+        create_recurrence_mock.assert_called_once()
+        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+
+    def test_retorna_400_sem_campos_obrigatorios(self, client):
+        usuario_id = 1
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json={})
+
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["error"] == "bad_request"
+
+    def test_retorna_400_frequencia_invalida(self, client):
+        usuario_id = 1
+        data_inicio = (date.today() + timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião",
+            "data_inicio": data_inicio,
+            "hora_compromisso": "10:00",
+            "frequencia": "diaria",
+            "dia_semana_ou_mes": "seg",
+            "quantidade_meses": 1,
+        }
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "frequencia" in data["detail"].lower()
+
+    def test_retorna_400_quantidade_meses_invalida(self, client):
+        usuario_id = 1
+        data_inicio = (date.today() + timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião",
+            "data_inicio": data_inicio,
+            "hora_compromisso": "10:00",
+            "frequencia": "semanal",
+            "dia_semana_ou_mes": "seg",
+            "quantidade_meses": 13,
+        }
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "quantidade_meses" in data["detail"].lower()
+
+    def test_cria_agendamentos_recorrentes_mensais(self, client, mock_db_conn, mocker):
+        usuario_id = 1
+        data_inicio = (date.today() + timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião mensal",
+            "data_inicio": data_inicio,
+            "hora_compromisso": "15:00",
+            "frequencia": "mensal",
+            "dia_semana_ou_mes": "15",
+            "quantidade_meses": 3,
+        }
+        agendamentos_fake = [
+            {
+                "id": 200,
+                "nome_compromisso": "Reunião mensal",
+                "data_compromisso": data_inicio,
+                "hora_compromisso": "15:00",
+                "status": "confirmado",
+                "recorrencia_id": "uuid-456",
+            },
+        ]
+        _, conn = mock_db_conn("src.routes.agendamentos.get_db_conn")
+
+        create_recurrence_mock = mocker.patch(
+            "src.routes.agendamentos.q.create_recurrence",
+            return_value=agendamentos_fake,
+        )
+        invalidate_prefix_mock = mocker.patch("src.routes.agendamentos.cache_invalidate_prefix")
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 201
+        assert resp.get_json() == agendamentos_fake
+        create_recurrence_mock.assert_called_once()
+        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+
+    def test_retorna_400_dia_semana_invalido(self, client):
+        usuario_id = 1
+        data_inicio = (date.today() + timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião",
+            "data_inicio": data_inicio,
+            "hora_compromisso": "10:00",
+            "frequencia": "semanal",
+            "dia_semana_ou_mes": "seg2",
+            "quantidade_meses": 1,
+        }
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "dia_semana" in data["detail"].lower() or "inválid" in data["detail"].lower()
+
+    def test_retorna_400_data_inicio_no_passado(self, client):
+        usuario_id = 1
+        data_passada = (date.today() - timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião",
+            "data_inicio": data_passada,
+            "hora_compromisso": "10:00",
+            "frequencia": "semanal",
+            "dia_semana_ou_mes": "seg",
+            "quantidade_meses": 1,
+        }
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "passado" in data["detail"].lower()
+
+    def test_invalida_cache_apos_criacao_recorrencia(self, client, mock_db_conn, mocker):
+        usuario_id = 1
+        data_inicio = (date.today() + timedelta(days=1)).isoformat()
+        payload = {
+            "nome_compromisso": "Reunião",
+            "data_inicio": data_inicio,
+            "hora_compromisso": "10:00",
+            "frequencia": "semanal",
+            "dia_semana_ou_mes": "seg",
+            "quantidade_meses": 1,
+        }
+        mock_db_conn("src.routes.agendamentos.get_db_conn")
+        mocker.patch("src.routes.agendamentos.q.create_recurrence", return_value=[])
+        invalidate_prefix_mock = mocker.patch("src.routes.agendamentos.cache_invalidate_prefix")
+
+        resp = client.post(f"/usuarios/{usuario_id}/agendamentos/recorrentes", json=payload)
+
+        assert resp.status_code == 201
+        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")

--- a/tests/test_agendamentos.py
+++ b/tests/test_agendamentos.py
@@ -380,7 +380,7 @@ class TestCancelAllAgendamentos:
 class TestCancelRecurrence:
     def test_cancela_agendamentos_recorrentes(self, client, mock_db_conn, mocker):
         usuario_id = 1
-        recorrencia_id = 42
+        recorrencia_id = "42"
         data_futura = (date.today() + timedelta(days=5)).isoformat()
         agendamentos_cancelados = [
             {
@@ -411,7 +411,7 @@ class TestCancelRecurrence:
 
     def test_retorna_lista_vazia_sem_recorrencia(self, client, mock_db_conn, mocker):
         usuario_id = 1
-        recorrencia_id = 999
+        recorrencia_id = "999"
         _, conn = mock_db_conn("src.routes.agendamentos.get_db_conn")
 
         cancel_recurrence_mock = mocker.patch(
@@ -422,14 +422,13 @@ class TestCancelRecurrence:
 
         resp = client.delete(f"/usuarios/{usuario_id}/agendamentos/recorrencia/{recorrencia_id}")
 
-        assert resp.status_code == 200
-        assert resp.get_json() == []
+        assert resp.status_code == 404
         cancel_recurrence_mock.assert_called_once_with(conn, usuario_id, recorrencia_id)
-        invalidate_prefix_mock.assert_called_once_with("agendamentos", f"{usuario_id}:")
+        invalidate_prefix_mock.assert_not_called()
 
     def test_invalida_cache_apos_cancelamento_recorrencia(self, client, mock_db_conn, mocker):
         usuario_id = 1
-        recorrencia_id = 42
+        recorrencia_id = "42"
         agendamentos_cancelados = [
             {
                 "nome_compromisso": "Reunião mensal",

--- a/tests/test_recurrence_generator.py
+++ b/tests/test_recurrence_generator.py
@@ -1,0 +1,126 @@
+"""
+Testes para a geração de datas de recorrência.
+"""
+from datetime import date, timedelta
+import pytest
+
+from src.utils.recurrence_generator import generate_recurrence_dates
+
+
+class TestGenerateRecurrenceDates:
+    def test_semanal_gera_datas_corretas(self):
+        """Testa geração de datas semanais."""
+        data_inicio = date(2026, 5, 11)  # Segunda-feira
+        datas = generate_recurrence_dates(data_inicio, "semanal", "seg", 1)
+        
+        assert len(datas) >= 4  # Mínimo de 4 segundas em um mês
+        assert all(d.weekday() == 0 for d in datas)  # Todos são segundas
+        assert datas[0] >= data_inicio
+
+    def test_semanal_com_diferentes_dias(self):
+        """Testa geração de datas em diferentes dias da semana."""
+        data_inicio = date(2026, 5, 11)
+        
+        for dia, weekday_num in [("seg", 0), ("ter", 1), ("qua", 2), ("qui", 3), ("sex", 4), ("sab", 5), ("dom", 6)]:
+            datas = generate_recurrence_dates(data_inicio, "semanal", dia, 1)
+            assert all(d.weekday() == weekday_num for d in datas), f"Falha para dia {dia}"
+
+    def test_quinzenal_gera_datas_a_cada_2_semanas(self):
+        """Testa geração de datas quinzenais."""
+        data_inicio = date(2026, 5, 11)  # Segunda-feira
+        datas = generate_recurrence_dates(data_inicio, "quinzenal", "seg", 2)
+        
+        assert len(datas) >= 2  # Mínimo de 2 datas em 2 meses
+        # Verificar intervalos de 14 dias
+        for i in range(len(datas) - 1):
+            diff = (datas[i+1] - datas[i]).days
+            assert 13 <= diff <= 15, f"Intervalo inválido: {diff} dias"
+
+    def test_mensal_gera_datas_no_mesmo_dia(self):
+        """Testa geração de datas mensais."""
+        data_inicio = date(2026, 5, 15)
+        datas = generate_recurrence_dates(data_inicio, "mensal", "15", 3)
+        
+        assert len(datas) >= 3  # Mínimo de 3 meses
+        assert all(d.day == 15 for d in datas)
+
+    def test_mensal_com_dia_invalido_usa_ultimo_dia_mes(self):
+        """Testa que meses com menos dias usam o último dia disponível."""
+        data_inicio = date(2026, 1, 31)
+        datas = generate_recurrence_dates(data_inicio, "mensal", "31", 3)
+        
+        assert len(datas) >= 2
+        # 2026 não é bissexto, então fevereiro tem 28 dias
+        assert datas[0].day == 31  # Janeiro
+        assert datas[1].day == 28  # Fevereiro (último dia)
+
+    def test_quantidade_meses_valida(self):
+        """Testa validação de quantidade_meses."""
+        data_inicio = date(2026, 5, 11)
+        
+        # Válido: 1 a 12
+        for qty in [1, 6, 12]:
+            datas = generate_recurrence_dates(data_inicio, "semanal", "seg", qty)
+            assert len(datas) > 0
+        
+        # Inválido: < 1 ou > 12
+        with pytest.raises(ValueError, match="quantidade_meses"):
+            generate_recurrence_dates(data_inicio, "semanal", "seg", 0)
+        
+        with pytest.raises(ValueError, match="quantidade_meses"):
+            generate_recurrence_dates(data_inicio, "semanal", "seg", 13)
+
+    def test_frequencia_invalida(self):
+        """Testa rejeição de frequência inválida."""
+        data_inicio = date(2026, 5, 11)
+        
+        with pytest.raises(ValueError, match="frequencia inválida"):
+            generate_recurrence_dates(data_inicio, "diaria", "seg", 1)
+
+    def test_dia_semana_invalido_para_semanal(self):
+        """Testa rejeição de dia da semana inválido."""
+        data_inicio = date(2026, 5, 11)
+        
+        with pytest.raises(ValueError, match="dia_semana inválido"):
+            generate_recurrence_dates(data_inicio, "semanal", "invalid", 1)
+
+    def test_dia_mes_invalido_para_mensal(self):
+        """Testa rejeição de dia do mês inválido."""
+        data_inicio = date(2026, 5, 11)
+        
+        with pytest.raises(ValueError, match="dia_mes"):
+            generate_recurrence_dates(data_inicio, "mensal", "32", 1)
+        
+        with pytest.raises(ValueError, match="dia_mes"):
+            generate_recurrence_dates(data_inicio, "mensal", "0", 1)
+
+    def test_datas_retornadas_em_ordem(self):
+        """Testa que as datas são retornadas em ordem crescente."""
+        data_inicio = date(2026, 5, 11)
+        datas = generate_recurrence_dates(data_inicio, "semanal", "seg", 3)
+        
+        assert datas == sorted(datas)
+
+    def test_semanal_quantidade_meses_12(self):
+        """Testa geração com 12 meses."""
+        data_inicio = date(2026, 1, 5)  # Segunda
+        datas = generate_recurrence_dates(data_inicio, "semanal", "seg", 12)
+        
+        # Deve gerar aproximadamente 52-56 semanas (12 meses inteiros)
+        assert len(datas) >= 52
+
+    def test_mensal_quantidade_meses_12(self):
+        """Testa geração mensal com 12 meses."""
+        data_inicio = date(2026, 1, 15)
+        datas = generate_recurrence_dates(data_inicio, "mensal", "15", 12)
+        
+        # Deve gerar 12-13 datas (um mês completo é gerado)
+        assert len(datas) >= 12 and len(datas) <= 13
+
+    def test_quinzenal_quantidade_meses_12(self):
+        """Testa geração quinzenal com 12 meses."""
+        data_inicio = date(2026, 1, 5)  # Segunda
+        datas = generate_recurrence_dates(data_inicio, "quinzenal", "seg", 12)
+        
+        # Deve gerar aproximadamente 26 datas (a cada 2 semanas)
+        assert len(datas) >= 24 and len(datas) <= 28


### PR DESCRIPTION
## Contexto

Esta branch implementa **agendamentos recorrentes** no data-svc, expandindo a capacidade de criar série de compromissos com frequências (semanal, quinzenal, mensal) e cancelá-las em lote. A funcionalidade permite que um usuário crie um único agendamento recorrente que gera múltiplos compromissos vinculados por um `recorrencia_id`.

Antes desta PR:

1. Não havia suporte para agendamentos recorrentes — cada compromisso precisava ser criado individualmente.
2. Não havia gerador de datas inteligente que calculasse automaticamente as datas baseado em frequência e dia da semana/mês.
3. Não havia forma de cancelar uma série de agendamentos de uma só vez.
4. O schema de `agendamentos` não tinha campo `recorrencia_id` para agrupar série de compromissos.
5. Não havia validação centralizada para payload de recorrências.

## O que foi alterado

### `src/utils/recurrence_generator.py` - gerador de datas para recorrências (novo arquivo)

Criado módulo `recurrence_generator.py` com função `generate_recurrence_dates()`:

1. Função principal `generate_recurrence_dates(data_inicio, frequencia, dia_semana_ou_mes, quantidade_meses)`:
   - Aceita frequências: `semanal`, `quinzenal`, `mensal`
   - Para semanal e quinzenal: `dia_semana_ou_mes` recebe dia da semana (seg, ter, qua, qui, sex, sab, dom)
   - Para mensal: `dia_semana_ou_mes` recebe número do dia (1-31)
   - Gera lista de datas ordenadas dentro do horizonte de `quantidade_meses` (1-12 meses)
   - Valida todos os parâmetros e lança `ValueError` para entrada inválida

2. Comportamento:
   - Semanal: gera compromissos no mesmo dia da semana, a cada 7 dias
   - Quinzenal: gera compromissos no mesmo dia da semana, a cada 14 dias
   - Mensal: gera compromissos no mesmo dia do mês (ou último dia se o mês tiver menos dias)

### `src/utils/validators.py` - validação para recorrências

1. Criada função `validate_recurrence_payload(body)`:
   - Requer campos: `nome_compromisso`, `data_inicio`, `hora_compromisso`, `frequencia`, `dia_semana_ou_mes`, `quantidade_meses`
   - Valida `nome_compromisso`: não pode ser vazio ou apenas espaços
   - Valida `data_inicio`: deve estar no formato YYYY-MM-DD e ser no futuro (ou hoje com hora no futuro)
   - Valida `hora_compromisso`: deve estar no formato HH:MM
   - Valida `frequencia`: deve ser `semanal`, `quinzenal` ou `mensal`
   - Valida `dia_semana_ou_mes`: 
     - Para semanal/quinzenal: deve ser dia da semana (seg, ter, qua, qui, sex, sab, dom)
     - Para mensal: deve ser número entre 1 e 31
   - Valida `quantidade_meses`: deve ser inteiro entre 1 e 12
   - Retorna dicionário com valores normalizados e parseados

### `src/queries/agendamentos.py` - funções para gerenciar recorrências

1. Criada função `create_recurrence(conn, usuario_id, nome_compromisso, datas, hora_compromisso)`:
   - Gera UUID único (`recorrencia_id`) para agrupar série de agendamentos
   - Cria múltiplos `INSERT` em uma única transação com todos os agendamentos
   - Todos os agendamentos recebem status `confirmado` e o mesmo `recorrencia_id`
   - Retorna lista de agendamentos criados com: `id`, `nome_compromisso`, `data_compromisso`, `hora_compromisso`, `status`, `recorrencia_id`

2. Criada função `cancel_recurrence(conn, usuario_id, recorrencia_id)`:
   - Cancela todos os agendamentos ativos da série (status em `pendente`, `confirmado`, `agendado`)
   - Utiliza o `recorrencia_id` para identificar a série
   - Retorna lista de agendamentos cancelados com: `nome_compromisso`, `data_compromisso`, `hora_compromisso`

### `src/routes/agendamentos.py` - endpoints para recorrências

1. Novo endpoint `POST /usuarios/<usuario_id>/agendamentos/recorrentes`:
   - Recebe payload com parâmetros de recorrência
   - Chama `validate_recurrence_payload()` para validar entrada
   - Gera lista de datas usando `generate_recurrence_dates()`
   - Chama `q.create_recurrence()` para inserir série de agendamentos
   - Invalida cache com prefixo `agendamentos:{usuario_id}:`
   - Retorna HTTP 201 com lista de agendamentos criados
   - Retorna HTTP 400 se validação falhar ou nenhuma data for gerada

2. Novo endpoint `DELETE /usuarios/<usuario_id>/agendamentos/recorrencia/<recorrencia_id>`:
   - Cancela toda uma série de agendamentos recorrentes
   - Chama `q.cancel_recurrence()`
   - Invalida cache com prefixo `agendamentos:{usuario_id}:`
   - Retorna HTTP 200 com lista de agendamentos cancelados

### `tests/test_agendamentos.py` - testes para endpoints de recorrências

1. Nova classe `TestCreateRecurrence` com testes de criação:
   - `test_cria_agendamentos_recorrentes_semanais()` — cria série semanal
   - `test_cria_agendamentos_recorrentes_quinzenais()` — cria série quinzenal
   - `test_cria_agendamentos_recorrentes_mensais()` — cria série mensal
   - `test_retorna_400_sem_campos_obrigatorios()` — rejeita payload incompleto
   - `test_retorna_400_frequencia_invalida()` — valida frequência
   - `test_retorna_400_dia_semana_invalida_para_semanal()` — valida dia da semana
   - `test_retorna_400_dia_mes_invalido_para_mensal()` — valida dia do mês (1-31)
   - `test_retorna_400_quantidade_meses_invalida()` — valida horizonte (1-12)
   - `test_invalida_cache_apos_criacao()` — cache é invalidado

2. Nova classe `TestCancelRecurrence` com testes de cancelamento:
   - `test_cancela_serie_completa()` — cancela todos os agendamentos da série
   - `test_invalida_cache_apos_cancelamento()` — cache é invalidado

### `tests/test_recurrence_generator.py` - testes para gerador (novo arquivo)

1. Classe `TestGenerateRecurrenceDates` com testes da geração de datas:
   - `test_gera_datas_semanais()` — valida sequência semanal
   - `test_gera_datas_quinzenais()` — valida sequência quinzenal
   - `test_gera_datas_mensais()` — valida sequência mensal
   - `test_respeita_horizonte_quantidade_meses()` — não gera datas além do horizonte
   - `test_lanca_erro_frequencia_invalida()` — valida frequência
   - `test_lanca_erro_dia_semana_invalida()` — valida dia da semana
   - `test_lanca_erro_dia_mes_invalido()` — valida dia do mês
   - `test_lanca_erro_quantidade_meses_invalida()` — valida horizonte

## Como testar

### Pré-requisito

1. Ativar ambiente virtual:

```bash
source .venv/bin/activate
```

### Executar testes unitários

1. Rodar testes do gerador de datas:

```bash
python -m pytest tests/test_recurrence_generator.py -v
```

2. Rodar testes de criação e cancelamento de recorrências:

```bash
python -m pytest tests/test_agendamentos.py::TestCreateRecurrence -v
python -m pytest tests/test_agendamentos.py::TestCancelRecurrence -v
```

3. Rodar toda suite de agendamentos:

```bash
python -m pytest tests/test_agendamentos.py -v
```

4. Rodar todos os testes:

```bash
python -m pytest tests -q
```

### Testar endpoints manualmente

1. Iniciar a aplicação:

```bash
export $(cat .env.local | xargs) && flask --app src.app run --port 5001 --debug
```

2. Criar agendamentos semanais:

```bash
curl -X POST http://localhost:5001/usuarios/1/agendamentos/recorrentes \
  -H "Content-Type: application/json" \
  -d '{
    "nome_compromisso": "Reunião semanal",
    "data_inicio": "2026-05-12",
    "hora_compromisso": "10:00",
    "frequencia": "semanal",
    "dia_semana_ou_mes": "seg",
    "quantidade_meses": 2
  }'
```

3. Criar agendamentos mensais:

```bash
curl -X POST http://localhost:5001/usuarios/1/agendamentos/recorrentes \
  -H "Content-Type: application/json" \
  -d '{
    "nome_compromisso": "Pagamento mensal",
    "data_inicio": "2026-05-15",
    "hora_compromisso": "09:00",
    "frequencia": "mensal",
    "dia_semana_ou_mes": "15",
    "quantidade_meses": 3
  }'
```

4. Cancelar série completa (usando `recorrencia_id` retornado na criação):

```bash
curl -X DELETE http://localhost:5001/usuarios/1/agendamentos/recorrencia/uuid-123-abc \
  -H "Content-Type: application/json"
```

5. Esperado: HTTP 201 para criação, HTTP 200 para cancelamento.

## Checklist de merge

- [ ] Confirmar que o endpoint POST responde em `POST /usuarios/<id>/agendamentos/recorrentes`.
- [ ] Confirmar que o endpoint DELETE responde em `DELETE /usuarios/<id>/agendamentos/recorrencia/<recorrencia_id>`.
- [ ] Confirmar que agendamentos criados recebem um UUID único (`recorrencia_id`) em comum.
- [ ] Confirmar que o retorno de criação contém: `id`, `nome_compromisso`, `data_compromisso`, `hora_compromisso`, `status`, `recorrencia_id`.
- [ ] Confirmar que DELETE retorna lista de agendamentos cancelados.
- [ ] Confirmar que validação aceita frequências: `semanal`, `quinzenal`, `mensal`.
- [ ] Confirmar que validação valida dias da semana (seg, ter, qua, qui, sex, sab, dom) para semanal/quinzenal.
- [ ] Confirmar que validação valida dias do mês (1-31) para mensal.
- [ ] Confirmar que validação valida horizonte (1-12 meses).
- [ ] Confirmar que datas são geradas corretamente para cada frequência.
- [ ] Confirmar que HTTP 400 é retornado para payload inválido.
- [ ] Confirmar que HTTP 400 é retornado se nenhuma data for gerada.
- [ ] Confirmar que cache é invalidado com prefixo `agendamentos:{usuario_id}:` em ambos endpoints.
- [ ] Executar `python -m pytest tests/test_recurrence_generator.py -v` — todos os testes passando.
- [ ] Executar `python -m pytest tests/test_agendamentos.py::TestCreateRecurrence -v` — todos os testes passando.
- [ ] Executar `python -m pytest tests/test_agendamentos.py::TestCancelRecurrence -v` — todos os testes passando.
- [ ] Executar `python -m pytest tests -q` — todas as suites passando.
- [ ] Atualizar workflow V9 para consumir o endpoint POST de criação de recorrência com os parâmetros corretos.
- [ ] Atualizar workflow V9 para consumir o endpoint DELETE de cancelamento de recorrência.

