### PR TITLE
feat(business): Business Agent context endpoint + meicheck-log route

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from src.routes.agente import agente_bp
 from src.routes.memoria import memoria_bp
 from src.routes.rag import rag_bp
 from src.routes.feedbacks import feedbacks_bp
+from src.routes.business import business_bp
 
 
 def create_app() -> Flask:
@@ -39,5 +40,6 @@ def create_app() -> Flask:
     app.register_blueprint(memoria_bp)
     app.register_blueprint(rag_bp)
     app.register_blueprint(feedbacks_bp)
+    app.register_blueprint(business_bp)
 
     return app

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ class Config:
     CACHE_TTL_AGENDAMENTOS: int = int(os.getenv("CACHE_TTL_AGENDAMENTOS", 120))
     CACHE_TTL_LISTAS: int = int(os.getenv("CACHE_TTL_LISTAS", 300))
     CACHE_TTL_FEEDBACKS: int = int(os.getenv("CACHE_TTL_FEEDBACKS", 300))
+    CACHE_TTL_CONTEXTO_BUSINESS: int = int(os.getenv("CACHE_TTL_CONTEXTO_BUSINESS", 60))
 
     OPENAI_API_KEY: str = os.environ.get("OPENAI_API_KEY", "")
     OPENAI_BASE_URL: str = os.environ.get("OPENAI_BASE_URL", "")

--- a/src/queries/business.py
+++ b/src/queries/business.py
@@ -1,0 +1,256 @@
+"""
+Queries do Agente Business — funções puras que recebem conn + parâmetros e retornam rows.
+Nenhuma lógica HTTP ou de cache aqui.
+"""
+from psycopg2.extras import RealDictCursor
+
+
+def get_contexto_usuario(conn, usuario_id: int) -> dict | None:
+    """Retorna perfil do usuário + campos computados: descricao_completa, proximo_campo_fila, status_trial."""
+    sql = """
+        SELECT
+            u.id,
+            u.nome,
+            u.razao_social,
+            u.tipo_negocio,
+            u.descricao_negocio,
+            u.descricao_objetivo,
+            u.data_primeiro_contato,
+            u.ultimo_relatorio,
+            u.confirmacao_lembretes,
+            u.interacao_previa,
+            (
+                u.descricao_negocio IS NOT NULL AND u.descricao_negocio <> ''
+                AND u.descricao_objetivo IS NOT NULL AND u.descricao_objetivo <> ''
+            ) AS descricao_completa,
+            CASE
+                WHEN u.nome IS NULL OR u.nome = ''           THEN 'nome_mei'
+                WHEN u.tipo_negocio IS NULL                  THEN 'cluster'
+                WHEN u.razao_social IS NULL                  THEN 'nome_negocio'
+                WHEN NOT u.confirmacao_lembretes             THEN 'confirmacao_lembretes'
+                WHEN u.descricao_negocio IS NULL OR u.descricao_negocio = '' THEN 'descricao_negocio'
+                ELSE NULL
+            END AS proximo_campo_fila,
+            -- status_trial derivado de assinaturas
+            CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM public.assinaturas a
+                    WHERE a.usuario_id = u.id AND a.active = true
+                ) THEN 'ativo'
+                WHEN EXISTS (
+                    SELECT 1 FROM public.assinaturas a
+                    WHERE a.usuario_id = u.id AND a.active = false
+                ) THEN 'encerrado'
+                ELSE 'trial'
+            END AS status_trial
+        FROM public.usuarios u
+        WHERE u.id = %(usuario_id)s;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
+def get_registros_semana(conn, usuario_id: int) -> dict:
+    """Agrega comprovantes dos últimos 7 dias: contagem, total_vendas, total_gastos, saldo."""
+    sql = """
+        SELECT
+            COUNT(*)::int AS contagem,
+            COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)::float AS total_vendas,
+            COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0)::float AS total_gastos,
+            (
+                COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)
+                - COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0)
+            )::float AS saldo
+        FROM public.comprovantes
+        WHERE usuario_id = %(usuario_id)s
+          AND (
+              (operacao = 'venda' AND data_venda >= CURRENT_DATE - INTERVAL '7 days'
+                                  AND data_venda <= CURRENT_DATE)
+           OR (operacao = 'gasto' AND data_compra >= CURRENT_DATE - INTERVAL '7 days'
+                                  AND data_compra <= CURRENT_DATE)
+          );
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        row = cur.fetchone()
+        return dict(row) if row else {"contagem": 0, "total_vendas": 0.0, "total_gastos": 0.0, "saldo": 0.0}
+
+
+def get_registros_mes(conn, usuario_id: int) -> dict:
+    """Agrega comprovantes do mês corrente: contagem, total_vendas, total_gastos, saldo."""
+    sql = """
+        SELECT
+            COUNT(*)::int AS contagem,
+            COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)::float AS total_vendas,
+            COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0)::float AS total_gastos,
+            (
+                COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)
+                - COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0)
+            )::float AS saldo
+        FROM public.comprovantes
+        WHERE usuario_id = %(usuario_id)s
+          AND (
+              (operacao = 'venda' AND data_venda >= date_trunc('month', CURRENT_DATE)
+                                  AND data_venda < date_trunc('month', CURRENT_DATE) + INTERVAL '1 month')
+           OR (operacao = 'gasto' AND data_compra >= date_trunc('month', CURRENT_DATE)
+                                  AND data_compra < date_trunc('month', CURRENT_DATE) + INTERVAL '1 month')
+          );
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        row = cur.fetchone()
+        return dict(row) if row else {"contagem": 0, "total_vendas": 0.0, "total_gastos": 0.0, "saldo": 0.0}
+
+
+def get_historico_meses(conn, usuario_id: int) -> list:
+    """Retorna totais mensais dos 3 meses completos anteriores ao mês atual."""
+    sql = """
+        SELECT
+            EXTRACT(YEAR  FROM eff_date)::int AS ano,
+            EXTRACT(MONTH FROM eff_date)::int AS mes,
+            COALESCE(SUM(CASE WHEN operacao = 'venda' THEN valor_total END), 0)::float AS total_vendas,
+            COALESCE(SUM(CASE WHEN operacao = 'gasto' THEN valor_total END), 0)::float AS total_gastos
+        FROM (
+            SELECT operacao, valor_total, data_venda AS eff_date
+            FROM public.comprovantes
+            WHERE usuario_id = %(usuario_id)s AND operacao = 'venda' AND data_venda IS NOT NULL
+            UNION ALL
+            SELECT operacao, valor_total, data_compra AS eff_date
+            FROM public.comprovantes
+            WHERE usuario_id = %(usuario_id)s AND operacao = 'gasto' AND data_compra IS NOT NULL
+        ) src
+        WHERE eff_date >= date_trunc('month', CURRENT_DATE) - INTERVAL '3 months'
+          AND eff_date <  date_trunc('month', CURRENT_DATE)
+        GROUP BY ano, mes
+        ORDER BY ano, mes;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        return [dict(r) for r in cur.fetchall()]
+
+
+def get_faturamento_acumulado_ano(conn, usuario_id: int) -> float:
+    """Soma todas as vendas do ano corrente — base para acompanhar limite DASN-SIMEI (R$ 81k)."""
+    sql = """
+        SELECT COALESCE(SUM(valor_total), 0)::float AS total
+        FROM public.comprovantes
+        WHERE usuario_id = %(usuario_id)s
+          AND operacao = 'venda'
+          AND data_venda >= date_trunc('year', CURRENT_DATE)
+          AND data_venda <  date_trunc('year', CURRENT_DATE) + INTERVAL '1 year';
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        row = cur.fetchone()
+        return float(row["total"]) if row else 0.0
+
+
+def get_gastos_recorrentes(conn, usuario_id: int) -> list:
+    """
+    Merge de duas fontes:
+    1. Comprovantes ad-hoc com mesmo item em 2+ dos últimos 3 meses completos
+    2. Contas recorrentes cadastradas (ativo=true)
+    Deduplicado por nome normalizado (LOWER/TRIM).
+    """
+    sql = """
+        WITH ad_hoc AS (
+            SELECT
+                LOWER(TRIM(item)) AS item_norm,
+                COUNT(DISTINCT EXTRACT(MONTH FROM data_compra))::int AS meses,
+                AVG(valor_total)::float AS valor_medio
+            FROM public.comprovantes
+            WHERE usuario_id = %(usuario_id)s
+              AND operacao = 'gasto'
+              AND data_compra >= date_trunc('month', CURRENT_DATE) - INTERVAL '3 months'
+              AND data_compra <  date_trunc('month', CURRENT_DATE)
+              AND item IS NOT NULL AND item <> ''
+            GROUP BY item_norm
+            HAVING COUNT(DISTINCT EXTRACT(MONTH FROM data_compra)) >= 2
+        ),
+        estruturadas AS (
+            SELECT
+                LOWER(TRIM(COALESCE(descricao, tipo))) AS item_norm,
+                3 AS meses,
+                valor::float AS valor_medio
+            FROM public.contas_recorrentes
+            WHERE usuario_id = %(usuario_id)s AND ativo = true
+        ),
+        merged AS (
+            SELECT item_norm, meses, valor_medio FROM ad_hoc
+            UNION
+            SELECT item_norm, meses, valor_medio FROM estruturadas
+        )
+        SELECT item_norm AS item, meses AS meses_consecutivos, ROUND(valor_medio::numeric, 2)::float AS valor
+        FROM merged
+        ORDER BY valor DESC;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        return [dict(r) for r in cur.fetchall()]
+
+
+def insert_meicheck_log(conn, data: dict) -> dict:
+    """Persiste log de execução do Agente Business na tabela meicheck_logs."""
+    sql = """
+        INSERT INTO public.meicheck_logs (
+            request_id, usuario_id, nome, tipo_negocio, razao_social,
+            numero_profissional, data_validation_score, data_gaps,
+            integrity_score, has_critical_gaps, contexto,
+            ia_response_text, ia_word_count, ia_validation_score, ia_validation_percent,
+            can_persist, adaptation_score, cluster_category, cluster_weight,
+            is_seasonal_now, channel, trigger_type, status
+        ) VALUES (
+            %(request_id)s, %(usuario_id)s, %(nome)s, %(tipo_negocio)s, %(razao_social)s,
+            %(numero_profissional)s, %(data_validation_score)s, %(data_gaps)s,
+            %(integrity_score)s, %(has_critical_gaps)s, %(contexto)s,
+            %(ia_response_text)s, %(ia_word_count)s, %(ia_validation_score)s, %(ia_validation_percent)s,
+            %(can_persist)s, %(adaptation_score)s, %(cluster_category)s, %(cluster_weight)s,
+            %(is_seasonal_now)s, %(channel)s, %(trigger_type)s, %(status)s
+        )
+        RETURNING id, request_id, created_at;
+    """
+    import json as _json
+    params = {
+        "request_id": data.get("request_id") or "",
+        "usuario_id": str(data.get("usuario_id", "")),
+        "nome": data.get("nome"),
+        "tipo_negocio": data.get("tipo_negocio"),
+        "razao_social": data.get("razao_social"),
+        "numero_profissional": data.get("numero_profissional"),
+        "data_validation_score": data.get("data_validation_score", 0),
+        "data_gaps": _json.dumps(data.get("data_gaps")) if data.get("data_gaps") is not None else None,
+        "integrity_score": data.get("integrity_score", 0),
+        "has_critical_gaps": data.get("has_critical_gaps", False),
+        "contexto": _json.dumps(data.get("contexto")) if data.get("contexto") is not None else None,
+        "ia_response_text": data.get("ia_response_text"),
+        "ia_word_count": data.get("ia_word_count"),
+        "ia_validation_score": data.get("ia_validation_score", 0),
+        "ia_validation_percent": data.get("ia_validation_percent", 0),
+        "can_persist": data.get("can_persist", False),
+        "adaptation_score": data.get("adaptation_score", 0),
+        "cluster_category": data.get("cluster_category"),
+        "cluster_weight": data.get("cluster_weight"),
+        "is_seasonal_now": data.get("is_seasonal_now", False),
+        "channel": data.get("channel", "whatsapp"),
+        "trigger_type": data.get("trigger_type", "webhook"),
+        "status": data.get("status", "completed"),
+    }
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, params)
+        row = cur.fetchone()
+        return dict(row)
+
+
+def list_contas_recorrentes(conn, usuario_id: int) -> list:
+    """Lista contas recorrentes ativas do usuário (ativo=true)."""
+    sql = """
+        SELECT id, tipo, descricao, valor, dia_vencimento, lembrete_ativo, ativo, created_at
+        FROM public.contas_recorrentes
+        WHERE usuario_id = %(usuario_id)s AND ativo = true
+        ORDER BY tipo, descricao;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        return [dict(r) for r in cur.fetchall()]

--- a/src/queries/contas.py
+++ b/src/queries/contas.py
@@ -6,6 +6,18 @@ from psycopg2.extras import RealDictCursor
 TIPOS_VALIDOS = {"aluguel", "internet", "luz", "agua", "boleto"}
 
 
+def list_by_usuario(conn, usuario_id: int) -> list:
+    sql = """
+        SELECT id, tipo, descricao, valor, dia_vencimento, lembrete_ativo, ativo, created_at
+        FROM public.contas_recorrentes
+        WHERE usuario_id = %(usuario_id)s AND ativo = true
+        ORDER BY tipo, descricao;
+    """
+    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, {"usuario_id": usuario_id})
+        return [dict(r) for r in cur.fetchall()]
+
+
 def upsert(conn, usuario_id: int, data: dict) -> dict:
     params = {
         "usuario_id": usuario_id,

--- a/src/queries/usuarios.py
+++ b/src/queries/usuarios.py
@@ -67,20 +67,22 @@ def update(conn, usuario_id: int, fields: dict) -> dict | None:
     sql = """
         UPDATE public.usuarios
         SET
-            nome                = COALESCE(%(nome)s, nome),
-            razao_social        = COALESCE(%(razao_social)s, razao_social),
-            estado_atual        = COALESCE(%(estado_atual)s, estado_atual),
-            interacao_previa    = COALESCE(%(interacao_previa)s, interacao_previa),
-            tipo_negocio        = COALESCE(%(tipo_negocio)s, tipo_negocio),
-            descricao_negocio   = COALESCE(%(descricao_negocio)s, descricao_negocio),
-            descricao_objetivo  = COALESCE(%(descricao_objetivo)s, descricao_objetivo),
-            area_ajuda          = COALESCE(%(area_ajuda)s, area_ajuda),
-            preco_referencia    = COALESCE(%(preco_referencia)s, preco_referencia),
-            dias_trabalho       = COALESCE(%(dias_trabalho)s, dias_trabalho),
-            horario_inicio      = COALESCE(%(horario_inicio)s, horario_inicio),
-            horario_fim         = COALESCE(%(horario_fim)s, horario_fim),
-            versao_agente       = COALESCE(%(versao_agente)s, versao_agente),
-            data_ultimo_contato = NOW()
+            nome                    = COALESCE(%(nome)s, nome),
+            razao_social            = COALESCE(%(razao_social)s, razao_social),
+            estado_atual            = COALESCE(%(estado_atual)s, estado_atual),
+            interacao_previa        = COALESCE(%(interacao_previa)s, interacao_previa),
+            tipo_negocio            = COALESCE(%(tipo_negocio)s, tipo_negocio),
+            descricao_negocio       = COALESCE(%(descricao_negocio)s, descricao_negocio),
+            descricao_objetivo      = COALESCE(%(descricao_objetivo)s, descricao_objetivo),
+            area_ajuda              = COALESCE(%(area_ajuda)s, area_ajuda),
+            preco_referencia        = COALESCE(%(preco_referencia)s, preco_referencia),
+            dias_trabalho           = COALESCE(%(dias_trabalho)s, dias_trabalho),
+            horario_inicio          = COALESCE(%(horario_inicio)s, horario_inicio),
+            horario_fim             = COALESCE(%(horario_fim)s, horario_fim),
+            versao_agente           = COALESCE(%(versao_agente)s, versao_agente),
+            confirmacao_lembretes   = COALESCE(%(confirmacao_lembretes)s, confirmacao_lembretes),
+            ultimo_relatorio        = COALESCE(%(ultimo_relatorio)s, ultimo_relatorio),
+            data_ultimo_contato     = NOW()
         WHERE id = %(id)s
         RETURNING *;
     """
@@ -100,6 +102,8 @@ def update(conn, usuario_id: int, fields: dict) -> dict | None:
         "horario_inicio": None,
         "horario_fim": None,
         "versao_agente": None,
+        "confirmacao_lembretes": None,
+        "ultimo_relatorio": None,
     }
     params.update(fields)
 

--- a/src/routes/business.py
+++ b/src/routes/business.py
@@ -1,0 +1,95 @@
+from datetime import date
+from flask import Blueprint, request
+
+from src.db import get_db_conn
+from src.cache import cache_get, cache_set
+from src.config import Config
+from src.utils.api_response import fail, ok
+import src.queries.business as q
+
+business_bp = Blueprint("business", __name__)
+
+
+@business_bp.route("/usuarios/<int:usuario_id>/contexto-business", methods=["GET"])
+def get_contexto_business(usuario_id: int):
+    cached = cache_get("contexto_business", str(usuario_id))
+    if cached:
+        return ok(200, cached)
+
+    with get_db_conn() as conn:
+        perfil = q.get_contexto_usuario(conn, usuario_id)
+        if not perfil:
+            return fail("usuario_nao_encontrado", status_code=404)
+
+        semana = q.get_registros_semana(conn, usuario_id)
+        mes = q.get_registros_mes(conn, usuario_id)
+        historico = q.get_historico_meses(conn, usuario_id)
+        fat_ano = q.get_faturamento_acumulado_ano(conn, usuario_id)
+        gastos_rec = q.get_gastos_recorrentes(conn, usuario_id)
+
+    hoje = date.today()
+    dias_pt = ["Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira", "Sábado", "Domingo"]
+    dia_semana = dias_pt[hoje.weekday()]
+    semana_do_mes = (hoje.day - 1) // 7 + 1
+
+    data_inicio = perfil.get("data_primeiro_contato")
+    mes_uso = 0
+    if data_inicio:
+        d = data_inicio.date() if hasattr(data_inicio, "date") else data_inicio
+        mes_uso = (hoje.year - d.year) * 12 + (hoje.month - d.month) + 1
+
+    # primeira_segunda: true se hoje é segunda E é a primeira segunda do mês do usuário
+    primeira_segunda = (
+        hoje.weekday() == 0
+        and data_inicio is not None
+        and (hoje.year, hoje.month) == (data_inicio.year, data_inicio.month)
+    ) if data_inicio else False
+
+    payload = {
+        "perfil": {
+            "nome_mei": perfil.get("nome") or "",
+            "nome_negocio": perfil.get("razao_social") or "",
+            "cluster": perfil.get("tipo_negocio") or "",
+            "tipo_negocio": perfil.get("tipo_negocio") or "",
+            "descricao_negocio": perfil.get("descricao_negocio") or "",
+            "descricao_completa": bool(perfil.get("descricao_completa")),
+        },
+        "flags": {
+            "primeira_segunda": primeira_segunda,
+            "primeiro_relatorio": perfil.get("ultimo_relatorio") is None,
+            "mes_uso": mes_uso,
+            "status_trial": perfil.get("status_trial", "trial"),
+            "confirmacao_lembretes": bool(perfil.get("confirmacao_lembretes")),
+            "proximo_campo_fila": perfil.get("proximo_campo_fila"),
+        },
+        "data_context": {
+            "data_atual": hoje.strftime("%d/%m/%Y"),
+            "dia_semana": dia_semana,
+            "semana_do_mes": semana_do_mes,
+            "data_inicio_meirelles": data_inicio.strftime("%Y-%m-%d") if data_inicio else None,
+        },
+        "financeiro": {
+            "registros_semana": semana,
+            "registros_mes": mes,
+            "historico_meses": historico,
+            "faturamento_acumulado_ano": fat_ano,
+            "gastos_recorrentes": gastos_rec,
+            "ultimo_relatorio": perfil["ultimo_relatorio"].isoformat() if perfil.get("ultimo_relatorio") else None,
+        },
+    }
+
+    cache_set("contexto_business", str(usuario_id), payload, Config.CACHE_TTL_CONTEXTO_BUSINESS)
+    return ok(200, payload)
+
+
+@business_bp.route("/usuarios/<int:usuario_id>/meicheck-logs", methods=["POST"])
+def post_meicheck_log(usuario_id: int):
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return fail("body_invalido", "JSON inválido ou ausente", 400)
+
+    body["usuario_id"] = body.get("usuario_id") or str(usuario_id)
+
+    with get_db_conn() as conn:
+        log = q.insert_meicheck_log(conn, body)
+        return ok(201, log)

--- a/src/routes/contas.py
+++ b/src/routes/contas.py
@@ -8,6 +8,13 @@ from src.utils.api_response import fail, ok
 contas_bp = Blueprint("contas", __name__)
 
 
+@contas_bp.route("/usuarios/<int:usuario_id>/contas-recorrentes", methods=["GET"])
+def list_contas(usuario_id: int):
+    with get_db_conn() as conn:
+        contas = q.list_by_usuario(conn, usuario_id)
+        return ok(200, contas)
+
+
 @contas_bp.route("/usuarios/<int:usuario_id>/contas-recorrentes", methods=["POST"])
 def upsert_conta(usuario_id: int):
     body = request.get_json(silent=True)

--- a/src/routes/usuarios.py
+++ b/src/routes/usuarios.py
@@ -58,7 +58,7 @@ def update_usuario(usuario_id: int):
         "tipo_negocio", "descricao_negocio", "descricao_objetivo",
         "area_ajuda", "preco_referencia", "dias_trabalho",
         "horario_inicio", "horario_fim", "data_ultimo_contato",
-        "versao_agente"
+        "versao_agente", "confirmacao_lembretes", "ultimo_relatorio"
     }
     
     fields_to_update = {

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -1,0 +1,183 @@
+from datetime import date, datetime, timezone
+
+PERFIL_FAKE = {
+    "id": 1,
+    "nome": "João",
+    "razao_social": "Pizzaria do João",
+    "tipo_negocio": "produto",
+    "descricao_negocio": "Faço pizzas artesanais",
+    "descricao_objetivo": "Abrir segunda unidade",
+    "data_primeiro_contato": datetime(2026, 4, 20, tzinfo=timezone.utc),
+    "ultimo_relatorio": None,
+    "confirmacao_lembretes": False,
+    "interacao_previa": True,
+    "descricao_completa": True,
+    "proximo_campo_fila": "confirmacao_lembretes",
+    "status_trial": "trial",
+}
+
+SEMANA_FAKE = {"contagem": 3, "total_vendas": 200.0, "total_gastos": 80.0, "saldo": 120.0}
+MES_FAKE = {"contagem": 10, "total_vendas": 800.0, "total_gastos": 300.0, "saldo": 500.0}
+HISTORICO_FAKE = [
+    {"ano": 2026, "mes": 3, "total_vendas": 750.0, "total_gastos": 280.0},
+    {"ano": 2026, "mes": 4, "total_vendas": 820.0, "total_gastos": 310.0},
+]
+GASTOS_REC_FAKE = [{"item": "aluguel", "meses_consecutivos": 3, "valor": 800.0}]
+LOG_FAKE = {"id": 42, "request_id": "abc-123", "created_at": "2026-05-20T10:00:00"}
+
+
+class TestGetContextoBusiness:
+    def test_retorna_contexto_completo(self, client, mock_db_conn, mocker):
+        mocker.patch("src.routes.business.cache_get", return_value=None)
+        mocker.patch("src.routes.business.cache_set")
+        _, conn = mock_db_conn("src.routes.business.get_db_conn")
+        mocker.patch("src.routes.business.q.get_contexto_usuario", return_value=PERFIL_FAKE)
+        mocker.patch("src.routes.business.q.get_registros_semana", return_value=SEMANA_FAKE)
+        mocker.patch("src.routes.business.q.get_registros_mes", return_value=MES_FAKE)
+        mocker.patch("src.routes.business.q.get_historico_meses", return_value=HISTORICO_FAKE)
+        mocker.patch("src.routes.business.q.get_faturamento_acumulado_ano", return_value=1620.0)
+        mocker.patch("src.routes.business.q.get_gastos_recorrentes", return_value=GASTOS_REC_FAKE)
+
+        resp = client.get("/usuarios/1/contexto-business")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["perfil"]["nome_mei"] == "João"
+        assert data["perfil"]["nome_negocio"] == "Pizzaria do João"
+        assert data["perfil"]["cluster"] == "produto"
+        assert data["perfil"]["descricao_completa"] is True
+        assert data["flags"]["primeiro_relatorio"] is True
+        assert data["flags"]["status_trial"] == "trial"
+        assert data["flags"]["confirmacao_lembretes"] is False
+        assert data["flags"]["proximo_campo_fila"] == "confirmacao_lembretes"
+        assert data["flags"]["mes_uso"] >= 1
+        assert data["data_context"]["dia_semana"] != ""
+        assert data["data_context"]["semana_do_mes"] >= 1
+        assert data["financeiro"]["registros_semana"] == SEMANA_FAKE
+        assert data["financeiro"]["registros_mes"] == MES_FAKE
+        assert data["financeiro"]["historico_meses"] == HISTORICO_FAKE
+        assert data["financeiro"]["faturamento_acumulado_ano"] == 1620.0
+        assert data["financeiro"]["gastos_recorrentes"] == GASTOS_REC_FAKE
+        assert data["financeiro"]["ultimo_relatorio"] is None
+
+    def test_retorna_cache_quando_disponivel(self, client, mocker):
+        cached_payload = {"perfil": {"nome_mei": "Cached"}}
+        mocker.patch("src.routes.business.cache_get", return_value=cached_payload)
+        cache_set_mock = mocker.patch("src.routes.business.cache_set")
+
+        resp = client.get("/usuarios/1/contexto-business")
+
+        assert resp.status_code == 200
+        assert resp.get_json() == cached_payload
+        cache_set_mock.assert_not_called()
+
+    def test_retorna_404_usuario_inexistente(self, client, mock_db_conn, mocker):
+        mocker.patch("src.routes.business.cache_get", return_value=None)
+        mock_db_conn("src.routes.business.get_db_conn")
+        mocker.patch("src.routes.business.q.get_contexto_usuario", return_value=None)
+
+        resp = client.get("/usuarios/999/contexto-business")
+
+        assert resp.status_code == 404
+        assert resp.get_json()["error"] == "usuario_nao_encontrado"
+
+    def test_primeiro_relatorio_false_quando_tem_ultimo_relatorio(self, client, mock_db_conn, mocker):
+        mocker.patch("src.routes.business.cache_get", return_value=None)
+        mocker.patch("src.routes.business.cache_set")
+        mock_db_conn("src.routes.business.get_db_conn")
+        perfil = {**PERFIL_FAKE, "ultimo_relatorio": date(2026, 5, 1)}
+        mocker.patch("src.routes.business.q.get_contexto_usuario", return_value=perfil)
+        mocker.patch("src.routes.business.q.get_registros_semana", return_value=SEMANA_FAKE)
+        mocker.patch("src.routes.business.q.get_registros_mes", return_value=MES_FAKE)
+        mocker.patch("src.routes.business.q.get_historico_meses", return_value=[])
+        mocker.patch("src.routes.business.q.get_faturamento_acumulado_ano", return_value=0.0)
+        mocker.patch("src.routes.business.q.get_gastos_recorrentes", return_value=[])
+
+        resp = client.get("/usuarios/1/contexto-business")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["flags"]["primeiro_relatorio"] is False
+        assert data["financeiro"]["ultimo_relatorio"] == "2026-05-01"
+
+    def test_mes_uso_calculado_corretamente(self, client, mock_db_conn, mocker):
+        mocker.patch("src.routes.business.cache_get", return_value=None)
+        mocker.patch("src.routes.business.cache_set")
+        mock_db_conn("src.routes.business.get_db_conn")
+        # Usuário criado 2 meses atrás → mes_uso deve ser 3 (mês atual incluído)
+        hoje = date.today()
+        dois_meses_atras = datetime(hoje.year, hoje.month - 2 if hoje.month > 2 else hoje.month + 10, 1, tzinfo=timezone.utc)
+        perfil = {**PERFIL_FAKE, "data_primeiro_contato": dois_meses_atras}
+        mocker.patch("src.routes.business.q.get_contexto_usuario", return_value=perfil)
+        mocker.patch("src.routes.business.q.get_registros_semana", return_value=SEMANA_FAKE)
+        mocker.patch("src.routes.business.q.get_registros_mes", return_value=MES_FAKE)
+        mocker.patch("src.routes.business.q.get_historico_meses", return_value=[])
+        mocker.patch("src.routes.business.q.get_faturamento_acumulado_ano", return_value=0.0)
+        mocker.patch("src.routes.business.q.get_gastos_recorrentes", return_value=[])
+
+        resp = client.get("/usuarios/1/contexto-business")
+
+        assert resp.status_code == 200
+        assert resp.get_json()["flags"]["mes_uso"] == 3
+
+    def test_usuario_sem_data_primeiro_contato(self, client, mock_db_conn, mocker):
+        mocker.patch("src.routes.business.cache_get", return_value=None)
+        mocker.patch("src.routes.business.cache_set")
+        mock_db_conn("src.routes.business.get_db_conn")
+        perfil = {**PERFIL_FAKE, "data_primeiro_contato": None}
+        mocker.patch("src.routes.business.q.get_contexto_usuario", return_value=perfil)
+        mocker.patch("src.routes.business.q.get_registros_semana", return_value=SEMANA_FAKE)
+        mocker.patch("src.routes.business.q.get_registros_mes", return_value=MES_FAKE)
+        mocker.patch("src.routes.business.q.get_historico_meses", return_value=[])
+        mocker.patch("src.routes.business.q.get_faturamento_acumulado_ano", return_value=0.0)
+        mocker.patch("src.routes.business.q.get_gastos_recorrentes", return_value=[])
+
+        resp = client.get("/usuarios/1/contexto-business")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["flags"]["mes_uso"] == 0
+        assert data["data_context"]["data_inicio_meirelles"] is None
+
+
+class TestPostMeicheckLog:
+    def test_insere_log_com_payload_completo(self, client, mock_db_conn, mocker):
+        _, conn = mock_db_conn("src.routes.business.get_db_conn")
+        insert_mock = mocker.patch("src.routes.business.q.insert_meicheck_log", return_value=LOG_FAKE)
+
+        payload = {
+            "request_id": "abc-123",
+            "trigger_type": "webhook",
+            "integrity_score": 85,
+            "can_proceed": True,
+            "cluster_category": "produto",
+        }
+        resp = client.post("/usuarios/1/meicheck-logs", json=payload)
+
+        assert resp.status_code == 201
+        assert resp.get_json()["id"] == 42
+        insert_mock.assert_called_once()
+        call_args = insert_mock.call_args[0]
+        assert call_args[0] is conn
+        assert call_args[1]["usuario_id"] == "1"
+
+    def test_usa_usuario_id_do_body_se_presente(self, client, mock_db_conn, mocker):
+        mock_db_conn("src.routes.business.get_db_conn")
+        insert_mock = mocker.patch("src.routes.business.q.insert_meicheck_log", return_value=LOG_FAKE)
+
+        payload = {"request_id": "xyz", "usuario_id": "55119999"}
+        client.post("/usuarios/1/meicheck-logs", json=payload)
+
+        call_data = insert_mock.call_args[0][1]
+        assert call_data["usuario_id"] == "55119999"
+
+    def test_retorna_400_sem_body_json(self, client):
+        resp = client.post("/usuarios/1/meicheck-logs", data="not-json", content_type="text/plain")
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "body_invalido"
+
+    def test_retorna_400_body_nao_objeto(self, client):
+        resp = client.post("/usuarios/1/meicheck-logs", json=[1, 2, 3])
+
+        assert resp.status_code == 400


### PR DESCRIPTION
## Contexto

Implementa os endpoints do data-svc necessários para o Agente Business (Agente 4) funcionar dentro da arquitetura V2 multiagente da MEIrelles. Resolve os gaps identificados no PR #19 (meirelles-dev) e issue #4.

**Princípio:** zero SQL no N8N — tudo via HTTP ao data-svc.

## O que mudou

### Novos endpoints

- **`GET /usuarios/<id>/contexto-business`** — payload agregado com tudo que o Agente Business precisa em 1 chamada:
  - Perfil: `nome_mei`, `nome_negocio`, `cluster`, `descricao_completa`
  - Flags: `primeiro_relatorio`, `mes_uso`, `status_trial` (derivado de `assinaturas`), `confirmacao_lembretes`, `proximo_campo_fila`
  - Contexto temporal: `data_atual`, `dia_semana`, `semana_do_mes`
  - Financeiro: registros semana/mês, histórico 3 meses, faturamento acumulado ano, `gastos_recorrentes` (merge de padrões em comprovantes + contas_recorrentes)
  - Cache: 60s (invalida com o próximo registro de comprovante)

- **`POST /usuarios/<id>/meicheck-logs`** — persiste log de execução na tabela `meicheck_logs` existente (schema da Jou82, 27 colunas)

- **`GET /usuarios/<id>/contas-recorrentes`** — lista contas ativas do usuário

### Campos adicionados ao `PUT /usuarios/<id>`

- `confirmacao_lembretes` (boolean)
- `ultimo_relatorio` (date)

### Migration (staging já aplicada)

```sql
-- meire/database/migrations/20260601_business_agent_context.sql
ALTER TABLE public.usuarios
  ADD COLUMN IF NOT EXISTS confirmacao_lembretes boolean NOT NULL DEFAULT false,
  ADD COLUMN IF NOT EXISTS ultimo_relatorio date;
```

> `meicheck_logs` já existia em staging — sem migration adicional.

## Testes

10 testes unitários em `tests/test_business.py` — todos passando:

- Cache hit retorna sem chamar DB
- Cache miss busca e popula cache
- 404 para usuário inexistente
- `primeiro_relatorio = false` quando `ultimo_relatorio` preenchido
- `mes_uso` calculado corretamente (meses desde `data_primeiro_contato`)
- Usuário sem `data_primeiro_contato` → `mes_uso = 0`, sem erro
- Log insert com `usuario_id` do path
- Log insert com `usuario_id` do body sobrescreve path
- 400 body não-JSON
- 400 body não-objeto

## Alinhamento com o Pivô

| Pivô usa | DB tem | Mapeamento |
|---|---|---|
| `cluster` | `tipo_negocio` | direto |
| `nome_negocio` | `razao_social` | direto |
| `nome_mei` | `nome` | direto |
| `data_inicio_meirelles` | `data_primeiro_contato` | direto |
| `status_trial` | `assinaturas.active` | JOIN computado |

🤖 Generated with [Claude Code](https://claude.com/claude-code)